### PR TITLE
Add experimental suspenseSSR config

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,6 +41,7 @@ const defaultConfig: { [key: string]: any } = {
     granularChunks: false,
     publicDirectory: false,
     modern: false,
+    suspenseSSR: false,
   },
   future: {
     excludeDefaultMomentLocales: false,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -77,6 +77,7 @@ export default class Server {
     canonicalBase: string
     documentMiddlewareEnabled: boolean
     dev?: boolean
+    suspenseSSR: boolean
   }
   private compression?: Middleware
   router: Router
@@ -124,6 +125,7 @@ export default class Server {
       staticMarkup,
       buildId: this.buildId,
       generateEtags,
+      suspenseSSR: this.nextConfig.experimental.suspenseSSR,
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side


### PR DESCRIPTION
Adds an experimental `suspenseSSR` config option. This will cause the server to render content in a `<React.Suspense />`.

I didn't add any tests, because I'm not sure how to: this currently requires a custom build of React, so it can't be done with an integration test.