### PR TITLE
Deprecate next/head

### DIFF
--- a/errors/next-head-deprecated.md
+++ b/errors/next-head-deprecated.md
@@ -1,0 +1,26 @@
+# `next/head` is deprecated
+
+#### Why This Error Occurred
+
+You are using `next/head`. This has been deprecated because it is incompatible with two major React features and performance optimizations:
+
+- Streaming Rendering: `<Head>` could appear anywhere in the component hierarchy, making it impossible to stream a response until the tree has been fully rendered
+- Concurrent Mode: `<Head>` relies on being rendered in a precise order, which cannot be guaranteed in this mode
+
+#### Possible Ways to Fix It
+
+Hoist head generation to the page level by defining a `head` component:
+
+```jsx
+export default function MyPage() {
+  return <span>Hello World</span>
+}
+
+export function head() => (
+  <>
+    <title>Valid Head</title>
+  </>
+)
+```
+
+The `head` component will be rendered with the same props as the page component, so you can use `getInitialProps` to e.g. fetch a dynamic title value.

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -15,6 +15,7 @@ import { HeadManagerContext } from '../next-server/lib/head-manager-context'
 import { DataManagerContext } from '../next-server/lib/data-manager-context'
 import { RouterContext } from '../next-server/lib/router-context'
 import { DataManager } from '../next-server/lib/data-manager'
+import { Head } from '../next-server/lib/head'
 import { parse as parseQs, stringify as stringifyQs } from 'querystring'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 
@@ -180,7 +181,14 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
       render({ App, Component, props, err, emitter })
     }
   })
-  const renderCtx = { App, Component, props, err: initialErr, emitter }
+  const renderCtx = {
+    App,
+    Component,
+    Head: mod.head,
+    props,
+    err: initialErr,
+    emitter
+  }
   render(renderCtx)
 
   return emitter
@@ -214,7 +222,9 @@ export async function renderError (props) {
   // Make sure we log the error to the console, otherwise users can't track down issues.
   console.error(err)
 
-  ErrorComponent = await pageLoader.loadPage('/_error')
+  const { page: ErrorComponent, mod } = await pageLoader.loadPageScript(
+    '/_error'
+  )
 
   // In production we do a normal render with the `ErrorComponent` as component.
   // If we've gotten here upon initial render, we can use the props from the server.
@@ -231,7 +241,13 @@ export async function renderError (props) {
     ? props.props
     : await loadGetInitialProps(App, appCtx)
 
-  await doRender({ ...props, err, Component: ErrorComponent, props: initProps })
+  await doRender({
+    ...props,
+    err,
+    Component: ErrorComponent,
+    Head: mod.head,
+    props: initProps
+  })
 }
 
 // If hydrate does not exist, eg in preact.
@@ -339,7 +355,7 @@ const wrapApp = App => props => {
   )
 }
 
-async function doRender ({ App, Component, props, err }) {
+async function doRender ({ App, Component, Head: PageHead, props, err }) {
   // Usual getInitialProps fetching is handled in next/router
   // this is for when ErrorComponent gets replaced by Component by HMR
   if (
@@ -366,6 +382,13 @@ async function doRender ({ App, Component, props, err }) {
   // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
   lastAppProps = appProps
 
+  const head =
+    PageHead != null ? (
+      <Head supressDeprecationWarning>
+        <PageHead {...props} />
+      </Head>
+    ) : null
+
   emitter.emit('before-reactdom-render', {
     Component,
     ErrorComponent,
@@ -375,7 +398,10 @@ async function doRender ({ App, Component, props, err }) {
   // We catch runtime errors using componentDidCatch which will trigger renderError
   renderReactElement(
     <AppContainer>
-      <App {...appProps} />
+      <>
+        {head}
+        <App {...appProps} />
+      </>
     </AppContainer>,
     appElement
   )

--- a/packages/next/next-server/lib/head.tsx
+++ b/packages/next/next-server/lib/head.tsx
@@ -135,7 +135,18 @@ const Effect = withSideEffect()
  * This component injects elements to `<head>` of your page.
  * To avoid duplicated `tags` in `<head>` you can use the `key` property, which will make sure every tag is only rendered once.
  */
-function Head({ children }: { children: React.ReactNode }) {
+function Head({
+  children,
+  suppressDeprecationWarning = false,
+}: {
+  children: React.ReactNode
+  suppressDeprecationWarning?: boolean
+}) {
+  if (process.env.NODE_ENV !== 'production' && !suppressDeprecationWarning) {
+    console.warn(
+      'Warning: `Head` is deprecated, add `head` to your page instead. https://err.sh/zeit/next.js/next-head-deprecated'
+    )
+  }
   return (
     <AmpStateContext.Consumer>
       {ampState => (

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -14,6 +14,7 @@ export function interopDefault(mod: any) {
 
 export type LoadComponentsReturnType = {
   Component: any
+  Head: any
   pageConfig: PageConfig
   unstable_getStaticProps?: (params: {
     params: any
@@ -38,6 +39,7 @@ export async function loadComponents(
     const Component = await requirePage(pathname, distDir, serverless)
     return {
       Component,
+      Head: Component.head,
       pageConfig: Component.config || {},
       unstable_getStaticProps: Component.unstable_getStaticProps,
     }
@@ -82,6 +84,7 @@ export async function loadComponents(
     App,
     Document,
     Component,
+    Head: ComponentMod.head,
     buildManifest,
     DocumentMiddleware,
     reactLoadableManifest,

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -158,6 +158,7 @@ type RenderOpts = {
     props: any
     revalidate: number | false
   }
+  Head: React.ComponentType
 }
 
 function renderDocument(
@@ -268,6 +269,7 @@ export async function renderToHTML(
     reactLoadableManifest,
     ErrorDebug,
     unstable_getStaticProps,
+    Head: PageHead,
   } = renderOpts
 
   const isSpr = !!unstable_getStaticProps
@@ -468,6 +470,12 @@ export async function renderToHTML(
   }
 
   let renderPage: RenderPage
+  const head =
+    PageHead != null ? (
+      <Head suppressDeprecationWarning>
+        <PageHead {...props.pageProps} />
+      </Head>
+    ) : null
 
   if (ampBindInitData) {
     const ssrPrepass = require('react-ssr-prepass')
@@ -485,11 +493,14 @@ export async function renderToHTML(
 
       const Application = () => (
         <AppContainer>
-          <EnhancedApp
-            Component={EnhancedComponent}
-            router={router}
-            {...props}
-          />
+          <>
+            {head}
+            <EnhancedApp
+              Component={EnhancedComponent}
+              router={router}
+              {...props}
+            />
+          </>
         </AppContainer>
       )
 
@@ -528,11 +539,14 @@ export async function renderToHTML(
       return render(
         renderElementToString,
         <AppContainer>
-          <EnhancedApp
-            Component={EnhancedComponent}
-            router={router}
-            {...props}
-          />
+          <>
+            {head}
+            <EnhancedApp
+              Component={EnhancedComponent}
+              router={router}
+              {...props}
+            />
+          </>
         </AppContainer>,
         ampState
       )

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Head from '../next-server/lib/head'
 import { NextPageContext } from '../next-server/lib/utils'
 
 const statusCodes: { [code: number]: string } = {
@@ -30,19 +29,10 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   }
 
   render() {
-    const { statusCode } = this.props
-    const title =
-      this.props.title ||
-      statusCodes[statusCode] ||
-      'An unexpected error has occurred'
+    const { statusCode, title } = getHeadFromProps(this.props)
 
     return (
       <div style={styles.error}>
-        <Head>
-          <title>
-            {statusCode}: {title}
-          </title>
-        </Head>
         <div>
           <style dangerouslySetInnerHTML={{ __html: 'body { margin: 0 }' }} />
           {statusCode ? <h1 style={styles.h1}>{statusCode}</h1> : null}
@@ -53,6 +43,27 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
       </div>
     )
   }
+}
+
+/**
+ * Head for the `Error` component.
+ */
+export function head(props: React.ComponentProps<typeof Error>) {
+  const { statusCode, title } = getHeadFromProps(props)
+  return (
+    <>
+      <title>
+        {statusCode}: {title}
+      </title>
+    </>
+  )
+}
+
+function getHeadFromProps(props: React.ComponentProps<typeof Error>) {
+  const { statusCode } = props
+  const title =
+    props.title || statusCodes[statusCode] || 'An unexpected error has occurred'
+  return { statusCode, title }
 }
 
 const styles: { [k: string]: React.CSSProperties } = {

--- a/test/integration/head/pages/dynamic-head.js
+++ b/test/integration/head/pages/dynamic-head.js
@@ -1,0 +1,15 @@
+function Dynamic () {
+  return <div />
+}
+
+Dynamic.getInitialProps = () => {
+  return { title: 'Dynamic Title' }
+}
+
+export default Dynamic
+
+export const head = ({ title }) => (
+  <>
+    <title>{title}</title>
+  </>
+)

--- a/test/integration/head/pages/static-head.js
+++ b/test/integration/head/pages/static-head.js
@@ -1,0 +1,7 @@
+export default () => <div />
+
+export const head = () => (
+  <>
+    <title>Static Title</title>
+  </>
+)

--- a/test/integration/head/test/index.test.js
+++ b/test/integration/head/test/index.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('Head', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('should render static heads', async () => {
+    const html = await renderViaHTTP(appPort, '/static-head')
+    expect(html).toMatch(/<title>Static Title<\/title>/)
+  })
+
+  it('should render dynamic heads', async () => {
+    const html = await renderViaHTTP(appPort, '/dynamic-head')
+    expect(html).toMatch(/<title>Dynamic Title<\/title>/)
+  })
+})


### PR DESCRIPTION
Implements https://github.com/zeit/next.js/issues/8981

In order to support streaming and concurrent mode, we need to deprecate `next/head`. This PR adds a warning when using `<Head>` and adds support for exporting a `Head` component from a page:

```jsx
export default function MyPage() {
  return <span>Hello World</span>
}

export function head() => (
  <>
    <title>Valid Head</title>
  </>
)
```

**Note**: The purpose of this PR is only to implement the deprecation warning and enable the new API. Further work is still needed for the `head` to support streaming.