### PR TITLE
Adding a lint rule for no unwanted polyfill.io features

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
+++ b/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
@@ -1,0 +1,99 @@
+const NEXT_POLYFILLED_FEATURES = [
+  'Array.prototype.@@iterator',
+  'Array.prototype.copyWithin',
+  'Array.prototype.fill',
+  'Array.prototype.find',
+  'Array.prototype.findIndex',
+  'Array.prototype.flatMap',
+  'Array.prototype.flat',
+  'Array.from',
+  'Array.prototype.includes',
+  'Array.of',
+  'Function.prototype.name',
+  'fetch',
+  'Map',
+  'Number.EPSILON',
+  'Number.Epsilon',
+  'Number.isFinite',
+  'Number.isNaN',
+  'Number.isInteger',
+  'Number.isSafeInteger',
+  'Number.MAX_SAFE_INTEGER',
+  'Number.MIN_SAFE_INTEGER',
+  'Object.entries',
+  'Object.getOwnPropertyDescriptor',
+  'Object.getOwnPropertyDescriptors',
+  'Object.is',
+  'Object.keys',
+  'Object.values',
+  'Reflect',
+  'Set',
+  'Symbol',
+  'Symbol.asyncIterator',
+  'String.prototype.codePointAt',
+  'String.prototype.endsWith',
+  'String.fromCodePoint',
+  'String.prototype.includes',
+  'String.prototype.@@iterator',
+  'String.prototype.padEnd',
+  'String.prototype.padStart',
+  'String.prototype.repeat',
+  'String.raw',
+  'String.prototype.startsWith',
+  'String.prototype.trimEnd',
+  'String.prototype.trimStart',
+  'String.prototype.trim',
+  'WeakMap',
+  'WeakSet',
+  'Promise',
+  'Promise.prototype.finally',
+  'es2015',
+  'es5',
+  'es6',
+]
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prohibit full page refresh for nextjs pages',
+      category: 'HTML',
+      recommended: true,
+    },
+    fixable: null, // or "code" or "whitespace"
+  },
+
+  create: function (context) {
+    return {
+      'JSXOpeningElement[name.name=script][attributes.length>0]'(node) {
+        const srcNode = node.attributes.find(
+          (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'src'
+        )
+        if (!srcNode || srcNode.value.type !== 'Literal') {
+          return
+        }
+        const src = srcNode.value.value
+        if (
+          src.startsWith('https://cdn.polyfill.io/v2/') ||
+          src.startsWith('https://polyfill.io/v3/')
+        ) {
+          const featureQueryString = new URL(src).searchParams.get('features')
+          const featuresRequested = (featureQueryString || '').split(',')
+          const unwantedFeatures = featuresRequested.filter((feature) =>
+            NEXT_POLYFILLED_FEATURES.includes(feature)
+          )
+          if (unwantedFeatures.length > 0) {
+            context.report({
+              node,
+              message: `You're requesting polyfills from polyfill.io which are already shipped with NextJS. Please remove ${unwantedFeatures.join(
+                ', '
+              )} from the features list.`,
+            })
+          }
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
+++ b/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
@@ -43,6 +43,8 @@ const NEXT_POLYFILLED_FEATURES = [
   'String.prototype.trimEnd',
   'String.prototype.trimStart',
   'String.prototype.trim',
+  'URL',
+  'URLSearchParams',
   'WeakMap',
   'WeakSet',
   'Promise',

--- a/test/eslint-plugin-next/no-unwanted-polyfillio.test.js
+++ b/test/eslint-plugin-next/no-unwanted-polyfillio.test.js
@@ -1,0 +1,88 @@
+const rule = require('@next/eslint-plugin-next/lib/rules/no-unwanted-polyfillio')
+
+const RuleTester = require('eslint').RuleTester
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
+    },
+  },
+})
+
+var ruleTester = new RuleTester()
+ruleTester.run('unwanted-polyfillsio', rule, {
+  valid: [
+    `import {Head} from 'next/document';
+
+      export class Blah extends Head {
+        render() {
+          return (
+            <div>
+              <h1>Hello title</h1>
+              <script src='https://polyfill.io/v3/polyfill.min.js?features=AbortController'></script>
+            </div>
+          );
+        }
+    }`,
+    `import {Head} from 'next/document';
+
+      export class Blah extends Head {
+        render() {
+          return (
+            <div>
+              <h1>Hello title</h1>
+              <script src='https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver'></script>
+            </div>
+          );
+        }
+    }`,
+  ],
+
+  invalid: [
+    {
+      code: `import {Head} from 'next/document';
+
+      export class Blah extends Head {
+        render() {
+          return (
+            <div>
+              <h1>Hello title</h1>
+              <script src='https://polyfill.io/v3/polyfill.min.js?features=WeakSet%2CPromise%2CPromise.prototype.finally%2Ces2015%2Ces5%2Ces6'></script>
+            </div>
+          );
+        }
+    }`,
+      errors: [
+        {
+          message:
+            "You're requesting polyfills from polyfill.io which are already shipped with NextJS. Please remove WeakSet, Promise, Promise.prototype.finally, es2015, es5, es6 from the features list.",
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: `
+      export class Blah {
+        render() {
+          return (
+            <div>
+              <h1>Hello title</h1>
+              <script src='https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.copyWithin'></script>
+            </div>
+          );
+        }
+    }`,
+      errors: [
+        {
+          message:
+            "You're requesting polyfills from polyfill.io which are already shipped with NextJS. Please remove Array.prototype.copyWithin from the features list.",
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
- Informs the user of the unwanted `polyfill.io` features that are not required due to the `next-polyfill` package.
- This could help the developer make an informed decision of whether they really need to rely on `polyfill.io` or the feature is small enough to be shipped in 1P bundle as a tradeoff for a 3rd party synchronous render blocking script.
