### PR TITLE
WIP: ESI prototype

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -97,6 +97,7 @@ export function createEntrypoints(
     loadedEnvFiles: Buffer.from(JSON.stringify(loadedEnvFiles)).toString(
       'base64'
     ),
+    edgeSideIncludes: config.experimental.edgeSideIncludes,
   }
 
   Object.keys(pages).forEach((page) => {

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -178,7 +178,19 @@ export type DocumentProps = DocumentInitialProps & {
   canonicalBase: string
   headTags: any[]
   unstable_runtimeJS?: false
+  unstable_esiPhase?: EsiPhase
 }
+
+export interface EsiStartPhase {
+  kind: 'start'
+  url: string
+}
+
+export interface EsiEndPhase {
+  kind: 'end'
+}
+
+export type EsiPhase = EsiStartPhase | EsiEndPhase
 
 /**
  * Next `API` route request

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -54,6 +54,7 @@ const defaultConfig: { [key: string]: any } = {
     productionBrowserSourceMaps: false,
     optimizeFonts: false,
     scrollRestoration: false,
+    edgeSideIncludes: false,
   },
   future: {
     excludeDefaultMomentLocales: false,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -55,7 +55,7 @@ import Router, {
 import { sendPayload } from './send-payload'
 import { serveStatic } from './serve-static'
 import { IncrementalCache } from './incremental-cache'
-import { execOnce } from '../lib/utils'
+import { execOnce, EsiPhase } from '../lib/utils'
 import { isBlockedPage } from './utils'
 import { compile as compilePathToRegex } from 'next/dist/compiled/path-to-regexp'
 import { loadEnvConfig } from '../../lib/load-env-config'
@@ -122,6 +122,7 @@ export default class Server {
     basePath: string
     optimizeFonts: boolean
     fontManifest: FontManifest
+    unstable_esiPhase?: EsiPhase
   }
   private compression?: Middleware
   private onErrorMiddleware?: ({ err }: { err: Error }) => Promise<void>
@@ -953,6 +954,25 @@ export default class Server {
       return components.Component
     }
 
+    const curUrl = parseUrl(req.url!, true)
+    const nextUrl = formatUrl({
+      ...curUrl,
+      search: undefined,
+      query: {
+        ...curUrl.query,
+        _nextEsiEnd: 1,
+      },
+    })
+
+    const extraRenderOpts = {
+      unstable_esiPhase: this.nextConfig.experimental.edgeSideIncludes
+        ? query._nextEsiEnd
+          ? { kind: 'end' as 'end' }
+          : { kind: 'start' as 'start', url: nextUrl }
+        : undefined,
+    }
+    delete query._nextEsiEnd
+
     // check request state
     const isLikeServerless =
       typeof components.Component === 'object' &&
@@ -1063,6 +1083,7 @@ export default class Server {
             res,
             'passthrough',
             {
+              ...extraRenderOpts,
               fontManifest: this.renderOpts.fontManifest,
             }
           )
@@ -1074,6 +1095,7 @@ export default class Server {
           const renderOpts: RenderOpts = {
             ...components,
             ...opts,
+            ...extraRenderOpts,
             isDataReq,
           }
           renderResult = await renderToHTML(

--- a/test/integration/esi/next.config.js
+++ b/test/integration/esi/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    edgeSideIncludes: true,
+  },
+}

--- a/test/integration/esi/pages/index.js
+++ b/test/integration/esi/pages/index.js
@@ -1,0 +1,9 @@
+export default function Index() {
+  return <span>Foo</span>
+}
+
+export async function getServerSideProps(ctx) {
+  return {
+    props: {},
+  }
+}


### PR DESCRIPTION
Implements "multi-flush" streaming. Allows splitting an app that uses `getServerSideProps` into two passes.

Currently intended to be used with a reverse proxy that implements ESI. A simple example would be:

```js
const express = require('express');
const fetch = require('node-fetch');
const trumpet = require('node-trumpet2');
const {join} = require('path');

const app = express();

app.get('/*', (req, res) => {
  const fetchUrl = req.headers.referer
    ? `${(new URL((new URL(req.headers.referer)).pathname.slice(1))).origin}${req.path}`
    : new URL(req.path.slice(1));

  fetch(fetchUrl.toString())
    .then(fetchRes => {

      if (fetchRes.headers.get('content-type').includes("text/html")) {
        const tr = trumpet();
        tr.selectAll("*", node => {
          if (node.name === "esi:include") {
            const src = node.getAttribute("src").replace("&amp;", "&");
            const str = node.createWriteStream({
              outer: true
            });
  
            const includeUrl = new URL(join(fetchUrl.origin, src));
            fetch(includeUrl.toString())
              .then(includeRes => {
                includeRes.body.pipe(str)
              });
          }
        });
  
        fetchRes.body.pipe(tr).pipe(res);
      } else {
        fetchRes.body.pipe(res);
      }
    });
});

const port = process.env.PORT || 8080;
app.listen(port, () => {
  console.log('Listening on port', port);
});
```