### PR TITLE
Support for new custom `Document` components

### DIFF
--- a/errors/modern-custom-document.md
+++ b/errors/modern-custom-document.md
@@ -1,0 +1,43 @@
+# Modern Custom Document
+
+#### Why This Error Occurred
+
+Your custom Document component (pages/\_document) either extends from `next/document` or uses unsupported hooks or features.
+
+#### Possible Ways to Fix It
+
+To support upcoming features in React like Suspense and React Server Components, you should use a modern Document component. A
+simple modern Document component looks something like this:
+
+```jsx
+import { useGetInitialProps, Html, Head, Main, NextScript } from 'next/document'
+
+// Only uncomment this method if your custom Document component needs it.
+// async function getInitialProps(ctx) {
+//   return { /* ... */ }
+// }
+
+export default function Document() {
+  // Uncomment this if you also uncommented `getInitialProps` above.
+  // const initialProps = useGetInitialProps(getInitialProps)
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+Please note the following restrictions:
+
+- You **must** use the `useGetInitialProps` hook instead of a `getInitialProps` property. The latter is not supported.
+
+- No hooks other than `useGetInitialProps` are currently supported. You **must not** use `useState`, `useCallback`, `useEffect`, etc.
+
+- Suspense is not currently supported. You **must** resolve any dependencies via `useGetInitialProps`
+
+- The `ctx` in `getInitialProps` no longer supports `renderPage`. You must upgrade your CSS-in-JS library to a version that supports streaming rendering.

--- a/packages/next/next-server/lib/document-context.ts
+++ b/packages/next/next-server/lib/document-context.ts
@@ -2,8 +2,8 @@ import React from 'react'
 import { DocumentInitialProps, DocumentProps } from './utils'
 
 export const DocumentContext = React.createContext<
-  DocumentInitialProps & DocumentProps
->(null as any)
+  (DocumentInitialProps & DocumentProps) | null
+>(null)
 
 if (process.env.NODE_ENV !== 'production') {
   DocumentContext.displayName = 'DocumentContext'

--- a/packages/next/next-server/lib/document-context.ts
+++ b/packages/next/next-server/lib/document-context.ts
@@ -1,7 +1,9 @@
 import React from 'react'
-import { DocumentProps } from './utils'
+import { DocumentInitialProps, DocumentProps } from './utils'
 
-export const DocumentContext = React.createContext<DocumentProps>(null as any)
+export const DocumentContext = React.createContext<
+  DocumentInitialProps & DocumentProps
+>(null as any)
 
 if (process.env.NODE_ENV !== 'production') {
   DocumentContext.displayName = 'DocumentContext'

--- a/packages/next/next-server/lib/initial-render-context.ts
+++ b/packages/next/next-server/lib/initial-render-context.ts
@@ -1,7 +1,0 @@
-import React from 'react'
-
-export const InitialRenderContext = React.createContext<boolean>(false)
-
-if (process.env.NODE_ENV !== 'production') {
-  InitialRenderContext.displayName = 'InitialRenderContext'
-}

--- a/packages/next/next-server/lib/initial-render-context.ts
+++ b/packages/next/next-server/lib/initial-render-context.ts
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const InitialRenderContext = React.createContext<boolean>(false)
+
+if (process.env.NODE_ENV !== 'production') {
+  InitialRenderContext.displayName = 'InitialRenderContext'
+}

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http'
 import { ParsedUrlQuery } from 'querystring'
-import React, { ComponentType } from 'react'
+import React, { ComponentClass, ComponentType, FunctionComponent } from 'react'
 import { UrlObject } from 'url'
 import { formatUrl } from './router/utils/format-url'
 import { NextRouter } from './router/router'
@@ -26,11 +26,15 @@ export type NextComponentType<
   getInitialProps?(context: C): IP | Promise<IP>
 }
 
-export type DocumentType = NextComponentType<
+export type ModernDocumentType = FunctionComponent<{}>
+export type ClassicDocumentType = NextComponentType<
   DocumentContext,
   DocumentInitialProps,
   DocumentProps
->
+> &
+  ComponentClass<DocumentProps>
+
+export type DocumentType = ClassicDocumentType | ModernDocumentType
 
 export type AppType = NextComponentType<
   AppContextType,

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -30,7 +30,7 @@ export const NEXT_IS_CUSTOM_DOCUMENT_SYMBOL = Symbol.for(
   'NEXT_IS_CUSTOM_DOCUMENT_SYMBOL'
 )
 
-export type ModernDocumentType = FunctionComponent<{}>
+export type ModernDocumentType = FunctionComponent<ModernDocumentProps>
 export type ClassicDocumentType = NextComponentType<
   DocumentContext,
   DocumentInitialProps,
@@ -169,14 +169,19 @@ export type AppPropsType<
 export type DocumentContext = NextPageContext & {
   renderPage?: RenderPage
 }
+export type ModernDocumentContext = {}
 
 export type DocumentInitialProps = RenderPageResult & {
   styles?: React.ReactElement[] | React.ReactFragment
 }
+export type ModernDocumentInitialProps = {}
 
 export type DocumentGetInitialProps = (
   ctx: DocumentContext
 ) => Promise<DocumentInitialProps> | DocumentInitialProps
+export type ModernDocumentGetInitialProps = (
+  ctx: ModernDocumentContext
+) => Promise<ModernDocumentInitialProps> | ModernDocumentInitialProps
 
 export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: NEXT_DATA
@@ -201,8 +206,11 @@ export type DocumentProps = DocumentInitialProps & {
   devOnlyCacheBusterQueryString: string
   scriptLoader: { defer?: string[]; eager?: any[] }
   locale?: string
-  getInitialPropsHandler: (fn: DocumentGetInitialProps) => DocumentInitialProps
+  getInitialPropsHandler: (
+    fn: ModernDocumentGetInitialProps | DocumentGetInitialProps
+  ) => ModernDocumentInitialProps | DocumentInitialProps
 }
+export type ModernDocumentProps = {}
 
 /**
  * Next `API` route request

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -167,7 +167,7 @@ export type AppPropsType<
 }
 
 export type DocumentContext = NextPageContext & {
-  renderPage: RenderPage
+  renderPage?: RenderPage
 }
 
 export type DocumentInitialProps = RenderPageResult & {
@@ -178,7 +178,7 @@ export type DocumentGetInitialProps = (
   ctx: DocumentContext
 ) => Promise<DocumentInitialProps> | DocumentInitialProps
 
-export type DocumentProps = {
+export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
   docComponentsRendered: {

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http'
 import { ParsedUrlQuery } from 'querystring'
-import React, { ComponentClass, ComponentType, FunctionComponent } from 'react'
+import React, { ComponentType, FunctionComponent } from 'react'
 import { UrlObject } from 'url'
 import { formatUrl } from './router/utils/format-url'
 import { NextRouter } from './router/router'
@@ -26,13 +26,18 @@ export type NextComponentType<
   getInitialProps?(context: C): IP | Promise<IP>
 }
 
+export const NEXT_IS_CUSTOM_DOCUMENT_SYMBOL = Symbol.for(
+  'NEXT_IS_CUSTOM_DOCUMENT_SYMBOL'
+)
+
 export type ModernDocumentType = FunctionComponent<{}>
 export type ClassicDocumentType = NextComponentType<
   DocumentContext,
   DocumentInitialProps,
   DocumentProps
-> &
-  ComponentClass<DocumentProps>
+> & {
+  [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL]: () => boolean
+}
 
 export type DocumentType = ClassicDocumentType | ModernDocumentType
 

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http'
 import { ParsedUrlQuery } from 'querystring'
-import { ComponentType } from 'react'
+import React, { ComponentType } from 'react'
 import { UrlObject } from 'url'
 import { formatUrl } from './router/utils/format-url'
 import { NextRouter } from './router/router'
@@ -169,7 +169,7 @@ export type DocumentGetInitialProps = (
   ctx: DocumentContext
 ) => Promise<DocumentInitialProps> | DocumentInitialProps
 
-export type DocumentProps = DocumentInitialProps & {
+export type DocumentProps = {
   __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
   docComponentsRendered: {

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -192,9 +192,7 @@ export type DocumentProps = DocumentInitialProps & {
   devOnlyCacheBusterQueryString: string
   scriptLoader: { defer?: string[]; eager?: any[] }
   locale?: string
-  legacyGetInitialPropsHandler: (
-    fn: DocumentGetInitialProps
-  ) => DocumentInitialProps
+  getInitialPropsHandler: (fn: DocumentGetInitialProps) => DocumentInitialProps
 }
 
 /**

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -30,12 +30,7 @@ export type DocumentType = NextComponentType<
   DocumentContext,
   DocumentInitialProps,
   DocumentProps
-> & {
-  renderDocument(
-    Document: DocumentType,
-    props: DocumentProps
-  ): React.ReactElement
-}
+>
 
 export type AppType = NextComponentType<
   AppContextType,

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -165,6 +165,10 @@ export type DocumentInitialProps = RenderPageResult & {
   styles?: React.ReactElement[] | React.ReactFragment
 }
 
+export type DocumentGetInitialProps = (
+  ctx: DocumentContext
+) => Promise<DocumentInitialProps> | DocumentInitialProps
+
 export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
@@ -188,6 +192,9 @@ export type DocumentProps = DocumentInitialProps & {
   devOnlyCacheBusterQueryString: string
   scriptLoader: { defer?: string[]; eager?: any[] }
   locale?: string
+  legacyGetInitialPropsHandler: (
+    fn: DocumentGetInitialProps
+  ) => DocumentInitialProps
 }
 
 /**

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -36,7 +36,7 @@ export type ClassicDocumentType = NextComponentType<
   DocumentInitialProps,
   DocumentProps
 > & {
-  [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL]: () => boolean
+  [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL]: (Document: ClassicDocumentType) => boolean
 }
 
 export type DocumentType = ClassicDocumentType | ModernDocumentType

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -444,8 +444,8 @@ function getModernDocument(
   const ClassicDocument = Document as ClassicDocumentType
   return function ModernDocument() {
     const initialProps = useGetInitialProps(ClassicDocument.getInitialProps!)
-    const props = useContext(DocumentComponentContext)!
-    return <ClassicDocument {...props} {...initialProps} />
+    const props = useContext(DocumentComponentContext)
+    return props ? <ClassicDocument {...props} {...initialProps} /> : null
   }
 }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -304,9 +304,6 @@ async function renderDocument(
   }
 
   const ModernDocument = getModernDocument(Document, getInitialPropsHandler)
-  const dynamicImportsIds = new Set<string | number>()
-  const dynamicImports = new Set<string>()
-  const docComponentsRendered: DocumentProps['docComponentsRendered'] = {}
 
   while (true) {
     try {
@@ -337,6 +334,10 @@ async function renderDocument(
     throw new Error(message)
   }
 
+  const dynamicImportsIds = new Set<string | number>()
+  const dynamicImports = new Set<string>()
+  const docComponentsRendered: DocumentProps['docComponentsRendered'] = {}
+
   for (const mod of reactLoadableModules) {
     const manifestItem: ManifestItem = reactLoadableManifest[mod]
 
@@ -364,7 +365,7 @@ async function renderDocument(
               nextExport, // If this is a page exported by `next export`
               autoExport, // If this is an auto exported page
               isFallback,
-              dynamicImportsIds:
+              dynamicIds:
                 dynamicImportsIds.size === 0
                   ? undefined
                   : Array.from(dynamicImportsIds),

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -344,7 +344,7 @@ async function renderDocument(
     )
   }
   const docProps = state.props
-  if (!docProps || typeof docProps.html !== 'string') {
+  if (isClassicDocument && (!docProps || typeof docProps.html !== 'string')) {
     const message = `"${getDisplayName(
       Document
     )}.getInitialProps()" should resolve to an object with a "html" prop set with a valid html string`

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -295,9 +295,7 @@ async function renderDocument(
   )
 
   let getInitialPropsState: GetInitialPropsState | null = null
-  const legacyGetInitialPropsHandler = (
-    getInitialProps: DocumentGetInitialProps
-  ) => {
+  const getInitialPropsHandler = (getInitialProps: DocumentGetInitialProps) => {
     if (!getInitialPropsState) {
       getInitialPropsState = {
         kind: 'PENDING',
@@ -373,7 +371,7 @@ async function renderDocument(
     devOnlyCacheBusterQueryString,
     scriptLoader: scriptLoader.current,
     locale,
-    legacyGetInitialPropsHandler,
+    getInitialPropsHandler,
     ...docProps,
   }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -67,6 +67,7 @@ import {
 } from '../../lib/load-custom-routes'
 import { DomainLocales } from './config'
 import { DocumentContext as DocumentComponentContext } from '../lib/document-context'
+import flush from 'styled-jsx/server'
 
 function noRouter() {
   const message =
@@ -363,6 +364,19 @@ async function renderDocument(
         dynamicImports.add(item)
       })
     }
+  }
+
+  const legacyDocProps: any = {}
+  if (!isClassicDocument) {
+    // TODO: Stop using renderPage for modern Documents
+    const enhanceApp = (App: any) => {
+      return (appProps: any) => <App {...appProps} />
+    }
+    const { html, head } = await documentCtx.renderPage!({ enhanceApp })
+    const styles = [...flush()]
+    legacyDocProps.html = html
+    legacyDocProps.head = head
+    legacyDocProps.styles = styles
   }
 
   let documentHTML =

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -332,22 +332,13 @@ async function renderDocument(
     ...docProps,
   }
 
-  const render = Document.prototype
-    ? () => {
-        const inst = new (Document as any)(renderProps)
-        return inst.render()
-      }
-    : () => {
-        return (Document as any)(renderProps)
-      }
-
   const res = {
     documentHTML:
       '<!DOCTYPE html>' +
       renderToStaticMarkup(
         <AmpStateContext.Provider value={ampState}>
           <DocumentComponentContext.Provider value={renderProps}>
-            {render()}
+            <Document {...renderProps} />
           </DocumentComponentContext.Provider>
         </AmpStateContext.Provider>
       ),

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -253,7 +253,7 @@ async function renderDocument(
     gip?: boolean
     appGip?: boolean
     devOnlyCacheBusterQueryString: string
-    scriptLoader: any
+    scriptLoader: { current: any }
     isPreview?: boolean
     autoExport?: boolean
     reactLoadableManifest: any
@@ -371,7 +371,7 @@ async function renderDocument(
     unstable_runtimeJS,
     unstable_JsPreload,
     devOnlyCacheBusterQueryString,
-    scriptLoader,
+    scriptLoader: scriptLoader.current,
     locale,
     legacyGetInitialPropsHandler,
     ...docProps,
@@ -732,9 +732,9 @@ export async function renderToHTML(
 
   const reactLoadableModules: string[] = []
 
-  let head: JSX.Element[] = defaultHead(inAmpMode)
+  let head: { current: JSX.Element[] } = { current: defaultHead(inAmpMode) }
 
-  let scriptLoader: any = {}
+  let scriptLoader: { current: any } = { current: {} }
 
   const AppContainer = ({ children }: any) => (
     <RouterContext.Provider value={router}>
@@ -742,10 +742,10 @@ export async function renderToHTML(
         <HeadManagerContext.Provider
           value={{
             updateHead: (state) => {
-              head = state
+              head.current = state
             },
             updateScripts: (scripts) => {
-              scriptLoader = scripts
+              scriptLoader.current = scripts
             },
             scripts: {},
             mountedInstances: new Set(),
@@ -1104,7 +1104,10 @@ export async function renderToHTML(
     options: ComponentsEnhancer = {}
   ): { html: string; head: any } => {
     if (ctx.err && ErrorDebug) {
-      return { html: renderToString(<ErrorDebug error={ctx.err} />), head }
+      return {
+        html: renderToString(<ErrorDebug error={ctx.err} />),
+        head: head.current,
+      }
     }
 
     if (dev && (props.router || props.Component)) {
@@ -1124,7 +1127,7 @@ export async function renderToHTML(
       </AppContainer>
     )
 
-    return { html, head }
+    return { html, head: head.current }
   }
   const documentCtx = { ...ctx, renderPage }
   const hybridAmp = ampState.hybrid

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -332,18 +332,15 @@ async function renderDocument(
     ...docProps,
   }
 
-  const res = {
-    documentHTML:
-      '<!DOCTYPE html>' +
-      renderToStaticMarkup(
-        <AmpStateContext.Provider value={ampState}>
-          <DocumentComponentContext.Provider value={renderProps}>
-            <Document {...renderProps} />
-          </DocumentComponentContext.Provider>
-        </AmpStateContext.Provider>
-      ),
-    bodyHTML: docProps.html,
-  }
+  const documentHTML =
+    '<!DOCTYPE html>' +
+    renderToStaticMarkup(
+      <AmpStateContext.Provider value={ampState}>
+        <DocumentComponentContext.Provider value={renderProps}>
+          <Document {...renderProps} />
+        </DocumentComponentContext.Provider>
+      </AmpStateContext.Provider>
+    )
 
   if (process.env.NODE_ENV !== 'production') {
     const nonRenderedComponents = []
@@ -368,7 +365,10 @@ async function renderDocument(
     }
   }
 
-  return res
+  return {
+    documentHTML,
+    bodyHTML: docProps.html,
+  }
 }
 
 const invalidKeysMsg = (methodName: string, invalidKeys: string[]) => {

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -295,8 +295,9 @@ async function renderDocument(
   )
 
   let getInitialPropsState: GetInitialPropsState | null = null
-  const legacyGetInitialPropsHandler = (fn?: DocumentGetInitialProps) => {
-    const getInitialProps: DocumentGetInitialProps = fn ?? (null as any)
+  const legacyGetInitialPropsHandler = (
+    getInitialProps: DocumentGetInitialProps
+  ) => {
     if (!getInitialPropsState) {
       getInitialPropsState = {
         kind: 'PENDING',

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -64,7 +64,6 @@ import {
 } from '../../lib/load-custom-routes'
 import { DomainLocales } from './config'
 import { DocumentContext as DocumentComponentContext } from '../lib/document-context'
-import { InitialRenderContext } from '../lib/initial-render-context'
 
 function noRouter() {
   const message =
@@ -358,11 +357,7 @@ async function renderDocument(
 
   while (true) {
     try {
-      renderToStaticMarkup(
-        <InitialRenderContext.Provider value={true}>
-          <WrapperDocument {...renderProps} />
-        </InitialRenderContext.Provider>
-      )
+      renderToStaticMarkup(<WrapperDocument {...renderProps} />)
       break
     } catch (renderError) {
       const state: GetInitialPropsState | null = getInitialPropsState as any

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -307,47 +307,6 @@ async function renderDocument(
   const dynamicImportsIds = new Set<string | number>()
   const dynamicImports = new Set<string>()
   const docComponentsRendered: DocumentProps['docComponentsRendered'] = {}
-  const renderProps = {
-    __NEXT_DATA__: {
-      props, // The result of getInitialProps
-      page: pathname, // The rendered page
-      query, // querystring parsed / passed by the user
-      buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
-      assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML
-      runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
-      nextExport, // If this is a page exported by `next export`
-      autoExport, // If this is an auto exported page
-      isFallback,
-      err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
-      gsp, // whether the page is getStaticProps
-      gssp, // whether the page is getServerSideProps
-      customServer, // whether the user is using a custom server
-      gip, // whether the page has getInitialProps
-      appGip, // whether the _app has getInitialProps
-      locale,
-      locales,
-      defaultLocale,
-      domainLocales,
-      isPreview,
-    },
-    buildManifest,
-    docComponentsRendered,
-    dangerousAsPath,
-    canonicalBase,
-    ampPath,
-    inAmpMode,
-    isDevelopment: !!dev,
-    hybridAmp,
-    dynamicImports: [],
-    assetPrefix,
-    headTags,
-    unstable_runtimeJS,
-    unstable_JsPreload,
-    devOnlyCacheBusterQueryString,
-    scriptLoader: scriptLoader.current,
-    locale,
-    getInitialPropsHandler,
-  }
 
   while (true) {
     try {
@@ -395,16 +354,50 @@ async function renderDocument(
       <AmpStateContext.Provider value={ampState}>
         <DocumentComponentContext.Provider
           value={{
-            ...renderProps,
-            ...docProps,
             __NEXT_DATA__: {
-              ...renderProps.__NEXT_DATA__,
-              dynamicIds:
+              props, // The result of getInitialProps
+              page: pathname, // The rendered page
+              query, // querystring parsed / passed by the user
+              buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
+              assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML
+              runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
+              nextExport, // If this is a page exported by `next export`
+              autoExport, // If this is an auto exported page
+              isFallback,
+              dynamicImportsIds:
                 dynamicImportsIds.size === 0
                   ? undefined
                   : Array.from(dynamicImportsIds),
+              err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
+              gsp, // whether the page is getStaticProps
+              gssp, // whether the page is getServerSideProps
+              customServer, // whether the user is using a custom server
+              gip, // whether the page has getInitialProps
+              appGip, // whether the _app has getInitialProps
+              locale,
+              locales,
+              defaultLocale,
+              domainLocales,
+              isPreview,
             },
+            buildManifest,
+            docComponentsRendered,
+            dangerousAsPath,
+            canonicalBase,
+            ampPath,
+            inAmpMode,
+            isDevelopment: !!dev,
+            hybridAmp,
             dynamicImports: Array.from(dynamicImports),
+            assetPrefix,
+            headTags,
+            unstable_runtimeJS,
+            unstable_JsPreload,
+            devOnlyCacheBusterQueryString,
+            scriptLoader: scriptLoader.current,
+            locale,
+            getInitialPropsHandler,
+            ...docProps,
           }}
         >
           <ModernDocument />

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -340,7 +340,7 @@ async function renderDocument(
   const state: GetInitialPropsState | null = getInitialPropsState as any
   if (state?.kind !== 'SUCCESS') {
     throw new Error(
-      'Expected getInitialProps to be ready. This is a bug in Next.js'
+      `Expected getInitialProps to be ready. This is a bug in Next.js.`
     )
   }
   const docProps = state.props
@@ -498,7 +498,7 @@ function getModernDocument(
   isClassicDocument: boolean
   isCustomDocument: boolean
 } {
-  if (Document.hasOwnProperty(NEXT_IS_CUSTOM_DOCUMENT_SYMBOL)) {
+  if ((Document as any)[NEXT_IS_CUSTOM_DOCUMENT_SYMBOL]) {
     const ClassicDocument = Document as ClassicDocumentType
     function ModernDocument() {
       const initialProps = useGetInitialProps(ClassicDocument.getInitialProps!)
@@ -508,7 +508,9 @@ function getModernDocument(
     return {
       Document: ModernDocument,
       isClassicDocument: true,
-      isCustomDocument: ClassicDocument[NEXT_IS_CUSTOM_DOCUMENT_SYMBOL](),
+      isCustomDocument: ClassicDocument[NEXT_IS_CUSTOM_DOCUMENT_SYMBOL](
+        ClassicDocument
+      ),
     }
   }
   return {

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -6,7 +6,6 @@ import {
 } from '../next-server/lib/constants'
 import { DocumentContext as DocumentComponentContext } from '../next-server/lib/document-context'
 import {
-  documentGetInitialProps,
   DocumentContext,
   DocumentGetInitialProps,
   DocumentInitialProps,

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -69,7 +69,7 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
       return (props: any) => <App {...props} />
     }
 
-    const { html, head } = await ctx.renderPage({ enhanceApp })
+    const { html, head } = await ctx.renderPage!({ enhanceApp })
     const styles = [...flush()]
     return { html, head, styles }
   }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -21,7 +21,6 @@ import { htmlEscapeJsonString } from '../server/htmlescape'
 import Script, {
   Props as ScriptLoaderProps,
 } from '../client/experimental-script'
-import { InitialRenderContext } from '../next-server/lib/initial-render-context'
 
 export { DocumentContext, DocumentInitialProps, DocumentProps }
 
@@ -93,13 +92,11 @@ export function Html(
     HTMLHtmlElement
   >
 ) {
-  const { inAmpMode, docComponentsRendered, locale } = useContext(
-    DocumentComponentContext
-  )
-  const isInitialRender = useContext(InitialRenderContext)
-  if (isInitialRender) {
+  const documentContext = useContext(DocumentComponentContext)
+  if (!documentContext) {
     return null
   }
+  const { inAmpMode, docComponentsRendered, locale } = documentContext
 
   docComponentsRendered.Html = true
 
@@ -136,7 +133,7 @@ export class Head extends Component<
       assetPrefix,
       devOnlyCacheBusterQueryString,
       dynamicImports,
-    } = this.context
+    } = this.context!
     const cssFiles = files.allFiles.filter((f) => f.endsWith('.css'))
     const sharedFiles: Set<string> = new Set(files.sharedFiles)
 
@@ -211,7 +208,7 @@ export class Head extends Component<
       dynamicImports,
       assetPrefix,
       devOnlyCacheBusterQueryString,
-    } = this.context
+    } = this.context!
 
     return (
       dynamicImports
@@ -245,7 +242,7 @@ export class Head extends Component<
       assetPrefix,
       devOnlyCacheBusterQueryString,
       scriptLoader,
-    } = this.context
+    } = this.context!
     const preloadFiles = files.allFiles.filter((file: string) => {
       return file.endsWith('.js')
     })
@@ -293,7 +290,7 @@ export class Head extends Component<
   }
 
   handleDocumentScriptLoaderItems(children: React.ReactNode): ReactNode[] {
-    const { scriptLoader } = this.context
+    const { scriptLoader } = this.context!
     const scriptLoaderItems: ScriptLoaderProps[] = []
     const filteredChildren: ReactNode[] = []
 
@@ -315,7 +312,7 @@ export class Head extends Component<
       filteredChildren.push(child)
     })
 
-    this.context.__NEXT_DATA__.scriptLoader = scriptLoaderItems
+    this.context!.__NEXT_DATA__.scriptLoader = scriptLoaderItems
 
     return filteredChildren
   }
@@ -350,13 +347,13 @@ export class Head extends Component<
       headTags,
       unstable_runtimeJS,
       unstable_JsPreload,
-    } = this.context
+    } = this.context!
     const disableRuntimeJS = unstable_runtimeJS === false
     const disableJsPreload = unstable_JsPreload === false
 
-    this.context.docComponentsRendered.Head = true
+    this.context!.docComponentsRendered.Head = true
 
-    let { head } = this.context
+    let { head } = this.context!
     let cssPreloads: Array<JSX.Element> = []
     let otherHeadElements: Array<JSX.Element> = []
     if (head) {
@@ -485,14 +482,14 @@ export class Head extends Component<
     }
 
     const files: DocumentFiles = getDocumentFiles(
-      this.context.buildManifest,
-      this.context.__NEXT_DATA__.page,
+      this.context!.buildManifest,
+      this.context!.__NEXT_DATA__.page,
       inAmpMode
     )
 
     return (
       <head {...this.props}>
-        {this.context.isDevelopment && (
+        {this.context!.isDevelopment && (
           <>
             <style
               data-next-hide-fouc
@@ -589,7 +586,7 @@ export class Head extends Component<
             {process.env.__NEXT_OPTIMIZE_CSS && (
               <noscript data-n-css={this.props.nonce ?? ''} />
             )}
-            {this.context.isDevelopment && (
+            {this.context!.isDevelopment && (
               // this element is used to mount development styles so the
               // ordering matches production
               // (by default, style-loader injects at the bottom of <head />)
@@ -607,7 +604,7 @@ export class Head extends Component<
 export function Main() {
   const { inAmpMode, html, docComponentsRendered } = useContext(
     DocumentComponentContext
-  )
+  )!
 
   docComponentsRendered.Main = true
 
@@ -635,7 +632,7 @@ export class NextScript extends Component<OriginProps> {
       assetPrefix,
       isDevelopment,
       devOnlyCacheBusterQueryString,
-    } = this.context
+    } = this.context!
 
     return dynamicImports.map((file) => {
       if (!file.endsWith('.js') || files.allFiles.includes(file)) return null
@@ -657,7 +654,7 @@ export class NextScript extends Component<OriginProps> {
   }
 
   getPreNextScripts() {
-    const { scriptLoader } = this.context
+    const { scriptLoader } = this.context!
 
     return (scriptLoader.eager || []).map((file: ScriptLoaderProps) => {
       const { strategy, ...props } = file
@@ -679,7 +676,7 @@ export class NextScript extends Component<OriginProps> {
       buildManifest,
       isDevelopment,
       devOnlyCacheBusterQueryString,
-    } = this.context
+    } = this.context!
 
     const normalScripts = files.allFiles.filter((file) => file.endsWith('.js'))
     const lowPriorityScripts = buildManifest.lowPriorityFiles?.filter((file) =>
@@ -710,7 +707,7 @@ export class NextScript extends Component<OriginProps> {
       assetPrefix,
       buildManifest,
       devOnlyCacheBusterQueryString,
-    } = this.context
+    } = this.context!
 
     return buildManifest.polyfillFiles
       .filter(
@@ -753,7 +750,7 @@ export class NextScript extends Component<OriginProps> {
       unstable_runtimeJS,
       docComponentsRendered,
       devOnlyCacheBusterQueryString,
-    } = this.context
+    } = this.context!
     const disableRuntimeJS = unstable_runtimeJS === false
 
     docComponentsRendered.NextScript = true
@@ -780,7 +777,7 @@ export class NextScript extends Component<OriginProps> {
                 this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN
               }
               dangerouslySetInnerHTML={{
-                __html: NextScript.getInlineScriptSource(this.context),
+                __html: NextScript.getInlineScriptSource(this.context!),
               }}
               data-ampdevmode
             />
@@ -808,8 +805,8 @@ export class NextScript extends Component<OriginProps> {
     }
 
     const files: DocumentFiles = getDocumentFiles(
-      this.context.buildManifest,
-      this.context.__NEXT_DATA__.page,
+      this.context!.buildManifest,
+      this.context!.__NEXT_DATA__.page,
       inAmpMode
     )
 
@@ -838,7 +835,7 @@ export class NextScript extends Component<OriginProps> {
               this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN
             }
             dangerouslySetInnerHTML={{
-              __html: NextScript.getInlineScriptSource(this.context),
+              __html: NextScript.getInlineScriptSource(this.context!),
             }}
           />
         )}
@@ -858,6 +855,6 @@ function getAmpPath(ampPath: string, asPath: string): string {
 export function useLegacyGetInitialProps(
   fn?: DocumentGetInitialProps
 ): DocumentInitialProps {
-  const ctx = useContext(DocumentComponentContext)
+  const ctx = useContext(DocumentComponentContext)!
   return ctx.getInitialPropsHandler(fn ?? Document.getInitialProps)
 }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -11,6 +11,7 @@ import {
   DocumentGetInitialProps,
   DocumentInitialProps,
   DocumentProps,
+  NEXT_IS_CUSTOM_DOCUMENT_SYMBOL,
 } from '../next-server/lib/utils'
 import {
   BuildManifest,
@@ -83,6 +84,10 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
         </body>
       </Html>
     )
+  }
+
+  [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL] = () => {
+    return this.constructor !== Document
   }
 }
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component, ReactElement, ReactNode, useContext } from 'react'
+import flush from 'styled-jsx/server'
 import {
   AMP_RENDER_TARGET,
   OPTIMIZED_FONT_PROVIDERS,
@@ -60,8 +61,16 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
    * `getInitialProps` hook returns the context object with the addition of `renderPage`.
    * `renderPage` callback executes `React` rendering logic synchronously to support server-rendering wrappers
    */
-  static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-    return documentGetInitialProps(ctx)
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<DocumentInitialProps> {
+    const enhanceApp = (App: any) => {
+      return (props: any) => <App {...props} />
+    }
+
+    const { html, head } = await ctx.renderPage({ enhanceApp })
+    const styles = [...flush()]
+    return { html, head, styles }
   }
 
   render() {

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -854,5 +854,5 @@ export function useLegacyGetInitialProps(
   fn?: DocumentGetInitialProps
 ): DocumentInitialProps {
   const ctx = useContext(DocumentComponentContext)
-  return ctx.legacyGetInitialPropsHandler(fn ?? Document.getInitialProps)
+  return ctx.getInitialPropsHandler(fn ?? Document.getInitialProps)
 }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -21,6 +21,7 @@ import { htmlEscapeJsonString } from '../server/htmlescape'
 import Script, {
   Props as ScriptLoaderProps,
 } from '../client/experimental-script'
+import { InitialRenderContext } from '../next-server/lib/initial-render-context'
 
 export { DocumentContext, DocumentInitialProps, DocumentProps }
 
@@ -95,6 +96,10 @@ export function Html(
   const { inAmpMode, docComponentsRendered, locale } = useContext(
     DocumentComponentContext
   )
+  const isInitialRender = useContext(InitialRenderContext)
+  if (isInitialRender) {
+    return null
+  }
 
   docComponentsRendered.Html = true
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -72,17 +72,6 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
     return { html, head, styles }
   }
 
-  static renderDocument<Y>(
-    DocumentComponent: new () => Document<Y>,
-    props: DocumentProps & Y
-  ): React.ReactElement {
-    return (
-      <DocumentComponentContext.Provider value={props}>
-        <DocumentComponent {...props} />
-      </DocumentComponentContext.Provider>
-    )
-  }
-
   render() {
     return (
       <Html>

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -7,6 +7,7 @@ import {
 } from '../next-server/lib/constants'
 import { DocumentContext as DocumentComponentContext } from '../next-server/lib/document-context'
 import {
+  ClassicDocumentType,
   DocumentContext,
   DocumentGetInitialProps,
   DocumentInitialProps,
@@ -86,8 +87,8 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
     )
   }
 
-  [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL] = () => {
-    return this.constructor !== Document
+  static [NEXT_IS_CUSTOM_DOCUMENT_SYMBOL] = (document: ClassicDocumentType) => {
+    return document.constructor !== Document
   }
 }
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types'
 import React, { Component, ReactElement, ReactNode, useContext } from 'react'
-import flush from 'styled-jsx/server'
 import {
   AMP_RENDER_TARGET,
   OPTIMIZED_FONT_PROVIDERS,
 } from '../next-server/lib/constants'
 import { DocumentContext as DocumentComponentContext } from '../next-server/lib/document-context'
 import {
+  documentGetInitialProps,
   DocumentContext,
   DocumentGetInitialProps,
   DocumentInitialProps,
@@ -61,16 +61,8 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
    * `getInitialProps` hook returns the context object with the addition of `renderPage`.
    * `renderPage` callback executes `React` rendering logic synchronously to support server-rendering wrappers
    */
-  static async getInitialProps(
-    ctx: DocumentContext
-  ): Promise<DocumentInitialProps> {
-    const enhanceApp = (App: any) => {
-      return (props: any) => <App {...props} />
-    }
-
-    const { html, head } = await ctx.renderPage({ enhanceApp })
-    const styles = [...flush()]
-    return { html, head, styles }
+  static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    return documentGetInitialProps(ctx)
   }
 
   render() {
@@ -851,8 +843,8 @@ function getAmpPath(ampPath: string, asPath: string): string {
 }
 
 export function useLegacyGetInitialProps(
-  fn: DocumentGetInitialProps
+  fn?: DocumentGetInitialProps
 ): DocumentInitialProps {
   const ctx = useContext(DocumentComponentContext)
-  return ctx.legacyGetInitialPropsHandler(fn)
+  return ctx.legacyGetInitialPropsHandler(fn ?? Document.getInitialProps)
 }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -9,9 +9,10 @@ import { DocumentContext as DocumentComponentContext } from '../next-server/lib/
 import {
   ClassicDocumentType,
   DocumentContext,
-  DocumentGetInitialProps,
   DocumentInitialProps,
   DocumentProps,
+  ModernDocumentGetInitialProps,
+  ModernDocumentInitialProps,
   NEXT_IS_CUSTOM_DOCUMENT_SYMBOL,
 } from '../next-server/lib/utils'
 import {
@@ -858,9 +859,9 @@ function getAmpPath(ampPath: string, asPath: string): string {
   return ampPath || `${asPath}${asPath.includes('?') ? '&' : '?'}amp=1`
 }
 
-export function useLegacyGetInitialProps(
-  fn?: DocumentGetInitialProps
-): DocumentInitialProps {
+export function useGetInitialProps(
+  fn?: ModernDocumentGetInitialProps
+): ModernDocumentInitialProps | null {
   const ctx = useContext(DocumentComponentContext)!
-  return ctx.getInitialPropsHandler(fn ?? Document.getInitialProps)
+  return fn ? ctx.getInitialPropsHandler(fn) : null
 }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -8,6 +8,7 @@ import {
 import { DocumentContext as DocumentComponentContext } from '../next-server/lib/document-context'
 import {
   DocumentContext,
+  DocumentGetInitialProps,
   DocumentInitialProps,
   DocumentProps,
 } from '../next-server/lib/utils'
@@ -847,4 +848,11 @@ export class NextScript extends Component<OriginProps> {
 
 function getAmpPath(ampPath: string, asPath: string): string {
   return ampPath || `${asPath}${asPath.includes('?') ? '&' : '?'}amp=1`
+}
+
+export function useLegacyGetInitialProps(
+  fn: DocumentGetInitialProps
+): DocumentInitialProps {
+  const ctx = useContext(DocumentComponentContext)
+  return ctx.legacyGetInitialPropsHandler(fn)
 }


### PR DESCRIPTION
Eventually, `pages/_document` is going to become a React Server Component. When it is, you won't need to use `getInitialProps`, because you can just fetch any required data using Suspense. Additionally, it has to be a function component, not a class component.

To allow folks to make the necessary changes incrementally, I'm introducing a `useLegacyGetInitialProps` hook. This lets you trivially rewrite your `pages/_document` **today** to look like:

```jsx
import { useLegacyGetInitialProps } from 'next/document'

async function getInitialProps(ctx) {
  /* ... */
}

export default function Document() {
  const props = useLegacyGetInitialProps(getInitialProps)
  return (
    /* ... */
  )
}
```

Note that this isn't really Suspense, as that isn't released yet. You can't use suspense libraries here yet. All you can (and should) do is use the provided `useLegacyGetInitialProps` helper. After suspense (+ Next.js support) is released, you'll be able to replace this call, if you want.

React Server Components have some other differences (e.g. no state or effects), but disallowing those are potentially breaking changes, so those will be gated behind a flag.