### PR TITLE
Add initial `RenderResult` support

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -637,16 +637,6 @@ export default class DevServer extends Server {
     return await loadDefaultErrorComponents(this.distDir)
   }
 
-  sendHTML(
-    req: IncomingMessage,
-    res: ServerResponse,
-    html: string
-  ): Promise<void> {
-    // In dev, we should not cache pages for any reason.
-    res.setHeader('Cache-Control', 'no-store, must-revalidate')
-    return super.sendHTML(req, res, html)
-  }
-
   protected setImmutableAssetCacheControl(res: ServerResponse): void {
     res.setHeader('Cache-Control', 'no-store, must-revalidate')
   }

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -30,6 +30,7 @@ import Server, {
   WrappedBuildError,
   ServerConstructor,
   FindComponentsResult,
+  RenderResult,
 } from '../next-server'
 import { normalizePagePath } from '../normalize-page-path'
 import Router, { Params, route } from '../router'
@@ -635,6 +636,16 @@ export default class DevServer extends Server {
     // TODO: See if this can be moved into hotReloader or removed.
     await this.hotReloader!.ensurePage('/_error')
     return await loadDefaultErrorComponents(this.distDir)
+  }
+
+  sendResult(
+    req: IncomingMessage,
+    res: ServerResponse,
+    result: RenderResult
+  ): Promise<void> {
+    // In dev, we should not cache pages for any reason.
+    res.setHeader('Cache-Control', 'no-store, must-revalidate')
+    return super.sendResult(req, res, result)
   }
 
   protected setImmutableAssetCacheControl(res: ServerResponse): void {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1446,7 +1446,7 @@ export default class Server {
     }
   }
 
-  private renderToHTMLWithComponents(
+  private renderToResultWithComponents(
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,
@@ -1936,7 +1936,7 @@ export default class Server {
       const result = await this.findPageComponents(pathname, query)
       if (result) {
         try {
-          return await this.renderToHTMLWithComponents(
+          return await this.renderToResultWithComponents(
             req,
             res,
             pathname,
@@ -1966,7 +1966,7 @@ export default class Server {
           )
           if (dynamicRouteResult) {
             try {
-              return await this.renderToHTMLWithComponents(
+              return await this.renderToResultWithComponents(
                 req,
                 res,
                 dynamicRoute.page,
@@ -2115,7 +2115,7 @@ export default class Server {
       }
 
       try {
-        return await this.renderToHTMLWithComponents(
+        return await this.renderToResultWithComponents(
           req,
           res,
           statusPage,
@@ -2140,7 +2140,7 @@ export default class Server {
       const fallbackComponents = await this.getFallbackErrorComponents()
 
       if (fallbackComponents) {
-        return this.renderToHTMLWithComponents(
+        return this.renderToResultWithComponents(
           req,
           res,
           '/_error',

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1450,7 +1450,7 @@ export default class Server {
     }
   }
 
-  private async renderToHTMLWithComponents(
+  private renderToHTMLWithComponents(
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1286,16 +1286,12 @@ export default class Server {
     await this.render404(req, res, parsedUrl)
   }
 
-  private async sendResult(
+  protected async sendResult(
     req: IncomingMessage,
     res: ServerResponse,
     { type, body, revalidateOptions }: RenderResult
   ): Promise<void> {
-    const { generateEtags, poweredByHeader, dev } = this.renderOpts
-    if (dev) {
-      // In dev, we should not cache pages for any reason.
-      res.setHeader('Cache-Control', 'no-store, must-revalidate')
-    }
+    const { generateEtags, poweredByHeader } = this.renderOpts
     return sendPayload(
       req,
       res,
@@ -2363,7 +2359,7 @@ export class WrappedBuildError extends Error {
   }
 }
 
-type RenderResult = {
+export type RenderResult = {
   type: 'html' | 'json'
   body: string
   revalidateOptions?: any

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1680,7 +1680,7 @@ export default class Server {
 
           // Stop the request chain here if the data we sent was up-to-date
           if (!cachedData.isStale) {
-            return null
+            return
           }
         }
 

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1456,21 +1456,19 @@ export default class Server {
     return new Promise(async (resolver, reject) => {
       try {
         let resolved = false
-        const resolveResult = (result: RenderResult | null) => {
-          if (!resolved) {
-            resolved = true
-            resolver(result)
-          }
-        }
-        const isResolved = () => resolved || isResSent(res)
-        return this.renderToResultWithComponentsInternal({
+        return await this.renderToResultWithComponentsInternal({
           req,
           res,
           pathname,
           findComponentsResult,
           opts,
-          resolveResult,
-          isResolved,
+          resolveResult: (result) => {
+            if (!resolved) {
+              resolved = true
+              resolver(result)
+            }
+          },
+          isResolved: () => resolved || isResSent(res),
         })
       } catch (err) {
         reject(err)
@@ -2034,7 +2032,7 @@ export default class Server {
       return result
     }
     res.statusCode = 404
-    return await this.renderErrorToResult(null, req, res, pathname, query)
+    return this.renderErrorToResult(null, req, res, pathname, query)
   }
 
   public async renderToHTML(

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1286,16 +1286,27 @@ export default class Server {
     await this.render404(req, res, parsedUrl)
   }
 
-  protected async sendHTML(
+  private async sendResult(
     req: IncomingMessage,
     res: ServerResponse,
-    html: string
+    { type, body, revalidateOptions }: RenderResult
   ): Promise<void> {
-    const { generateEtags, poweredByHeader } = this.renderOpts
-    return sendPayload(req, res, html, 'html', {
-      generateEtags,
-      poweredByHeader,
-    })
+    const { generateEtags, poweredByHeader, dev } = this.renderOpts
+    if (dev) {
+      // In dev, we should not cache pages for any reason.
+      res.setHeader('Cache-Control', 'no-store, must-revalidate')
+    }
+    return sendPayload(
+      req,
+      res,
+      body,
+      type,
+      {
+        generateEtags,
+        poweredByHeader,
+      },
+      revalidateOptions
+    )
   }
 
   public async render(
@@ -1345,13 +1356,13 @@ export default class Server {
       return this.render404(req, res, parsedUrl)
     }
 
-    const html = await this.renderToHTML(req, res, pathname, query)
+    const result = await this.renderToResult(req, res, pathname, query)
     // Request was ended by the user
-    if (html === null) {
+    if (result === null) {
       return
     }
 
-    return this.sendHTML(req, res, html)
+    return this.sendResult(req, res, result)
   }
 
   protected async findPageComponents(
@@ -1446,459 +1457,465 @@ export default class Server {
     { components, query }: FindComponentsResult,
     opts: RenderOptsPartial
   ): Promise<RenderResult | null> {
-    const is404Page = pathname === '/404'
-    const is500Page = pathname === '/500'
+    return new Promise(async (resolveResult, rejectResult) => {
+      try {
+        const is404Page = pathname === '/404'
+        const is500Page = pathname === '/500'
 
-    const isLikeServerless =
-      typeof components.Component === 'object' &&
-      typeof (components.Component as any).renderReqToHTML === 'function'
-    const isSSG = !!components.getStaticProps
-    const hasServerProps = !!components.getServerSideProps
-    const hasStaticPaths = !!components.getStaticPaths
-    const hasGetInitialProps = !!(components.Component as any).getInitialProps
+        const isLikeServerless =
+          typeof components.Component === 'object' &&
+          typeof (components.Component as any).renderReqToHTML === 'function'
+        const isSSG = !!components.getStaticProps
+        const hasServerProps = !!components.getServerSideProps
+        const hasStaticPaths = !!components.getStaticPaths
+        const hasGetInitialProps = !!(components.Component as any)
+          .getInitialProps
 
-    // Toggle whether or not this is a Data request
-    const isDataReq = !!query._nextDataReq && (isSSG || hasServerProps)
-    delete query._nextDataReq
+        // Toggle whether or not this is a Data request
+        const isDataReq = !!query._nextDataReq && (isSSG || hasServerProps)
+        delete query._nextDataReq
 
-    // we need to ensure the status code if /404 is visited directly
-    if (is404Page && !isDataReq) {
-      res.statusCode = 404
-    }
-
-    // ensure correct status is set when visiting a status page
-    // directly e.g. /500
-    if (STATIC_STATUS_PAGES.includes(pathname)) {
-      res.statusCode = parseInt(pathname.substr(1), 10)
-    }
-
-    // handle static page
-    if (typeof components.Component === 'string') {
-      return {
-        type: 'html',
-        body: components.Component,
-      }
-    }
-
-    if (!query.amp) {
-      delete query.amp
-    }
-
-    const locale = query.__nextLocale as string
-    const defaultLocale = isSSG
-      ? this.nextConfig.i18n?.defaultLocale
-      : (query.__nextDefaultLocale as string)
-
-    const { i18n } = this.nextConfig
-    const locales = i18n?.locales
-
-    let previewData: PreviewData
-    let isPreviewMode = false
-
-    if (hasServerProps || isSSG) {
-      previewData = tryGetPreviewData(req, res, this.renderOpts.previewProps)
-      isPreviewMode = previewData !== false
-    }
-
-    // Compute the iSSG cache key. We use the rewroteUrl since
-    // pages with fallback: false are allowed to be rewritten to
-    // and we need to look up the path by the rewritten path
-    let urlPathname = parseUrl(req.url || '').pathname || '/'
-
-    let resolvedUrlPathname = (req as any)._nextRewroteUrl
-      ? (req as any)._nextRewroteUrl
-      : urlPathname
-
-    urlPathname = removePathTrailingSlash(urlPathname)
-    resolvedUrlPathname = normalizeLocalePath(
-      removePathTrailingSlash(resolvedUrlPathname),
-      this.nextConfig.i18n?.locales
-    ).pathname
-
-    const stripNextDataPath = (path: string) => {
-      if (path.includes(this.buildId)) {
-        const splitPath = path.substring(
-          path.indexOf(this.buildId) + this.buildId.length
-        )
-
-        path = denormalizePagePath(splitPath.replace(/\.json$/, ''))
-      }
-
-      if (this.nextConfig.i18n) {
-        return normalizeLocalePath(path, locales).pathname
-      }
-      return path
-    }
-
-    const handleRedirect = (pageData: any) => {
-      const redirect = {
-        destination: pageData.pageProps.__N_REDIRECT,
-        statusCode: pageData.pageProps.__N_REDIRECT_STATUS,
-        basePath: pageData.pageProps.__N_REDIRECT_BASE_PATH,
-      }
-      const statusCode = getRedirectStatus(redirect)
-      const { basePath } = this.nextConfig
-
-      if (
-        basePath &&
-        redirect.basePath !== false &&
-        redirect.destination.startsWith('/')
-      ) {
-        redirect.destination = `${basePath}${redirect.destination}`
-      }
-
-      if (statusCode === PERMANENT_REDIRECT_STATUS) {
-        res.setHeader('Refresh', `0;url=${redirect.destination}`)
-      }
-
-      res.statusCode = statusCode
-      res.setHeader('Location', redirect.destination)
-      res.end()
-    }
-
-    // remove /_next/data prefix from urlPathname so it matches
-    // for direct page visit and /_next/data visit
-    if (isDataReq) {
-      resolvedUrlPathname = stripNextDataPath(resolvedUrlPathname)
-      urlPathname = stripNextDataPath(urlPathname)
-    }
-
-    let ssgCacheKey =
-      isPreviewMode || !isSSG || this.minimalMode
-        ? undefined // Preview mode bypasses the cache
-        : `${locale ? `/${locale}` : ''}${
-            (pathname === '/' || resolvedUrlPathname === '/') && locale
-              ? ''
-              : resolvedUrlPathname
-          }${query.amp ? '.amp' : ''}`
-
-    if ((is404Page || is500Page) && isSSG) {
-      ssgCacheKey = `${locale ? `/${locale}` : ''}${pathname}${
-        query.amp ? '.amp' : ''
-      }`
-    }
-
-    if (ssgCacheKey) {
-      // we only encode path delimiters for path segments from
-      // getStaticPaths so we need to attempt decoding the URL
-      // to match against and only escape the path delimiters
-      // this allows non-ascii values to be handled e.g. Japanese characters
-
-      // TODO: investigate adding this handling for non-SSG pages so
-      // non-ascii names work there also
-      ssgCacheKey = ssgCacheKey
-        .split('/')
-        .map((seg) => {
-          try {
-            seg = escapePathDelimiters(decodeURIComponent(seg), true)
-          } catch (_) {
-            // An improperly encoded URL was provided, this is considered
-            // a bad request (400)
-            const err: Error & { code?: string } = new Error(
-              'failed to decode param'
-            )
-            err.code = 'DECODE_FAILED'
-            throw err
-          }
-          return seg
-        })
-        .join('/')
-    }
-
-    // Complete the response with cached data if its present
-    const cachedData = ssgCacheKey
-      ? await this.incrementalCache.get(ssgCacheKey)
-      : undefined
-
-    if (cachedData) {
-      const data = isDataReq
-        ? JSON.stringify(cachedData.pageData)
-        : cachedData.html
-
-      const revalidateOptions = !this.renderOpts.dev
-        ? {
-            // When the page is 404 cache-control should not be added
-            private: isPreviewMode || is404Page,
-            stateful: false, // GSP response
-            revalidate:
-              cachedData.curRevalidate !== undefined
-                ? cachedData.curRevalidate
-                : /* default to minimum revalidate (this should be an invariant) */ 1,
-          }
-        : undefined
-
-      if (!isDataReq && cachedData.pageData?.pageProps?.__N_REDIRECT) {
-        await handleRedirect(cachedData.pageData)
-      } else if (cachedData.isNotFound) {
-        if (revalidateOptions) {
-          setRevalidateHeaders(res, revalidateOptions)
-        }
-        if (isDataReq) {
+        // we need to ensure the status code if /404 is visited directly
+        if (is404Page && !isDataReq) {
           res.statusCode = 404
-          res.end('{"notFound":true}')
-        } else {
-          await this.render404(req, res, {
-            pathname,
-            query,
-          } as UrlWithParsedQuery)
-        }
-      } else {
-        sendPayload(
-          req,
-          res,
-          data,
-          isDataReq ? 'json' : 'html',
-          {
-            generateEtags: this.renderOpts.generateEtags,
-            poweredByHeader: this.renderOpts.poweredByHeader,
-          },
-          revalidateOptions
-        )
-      }
-
-      // Stop the request chain here if the data we sent was up-to-date
-      if (!cachedData.isStale) {
-        return null
-      }
-    }
-
-    // If we're here, that means data is missing or it's stale.
-    const maybeCoalesceInvoke = ssgCacheKey
-      ? (fn: any) => withCoalescedInvoke(fn).bind(null, ssgCacheKey!, [])
-      : (fn: any) => async () => {
-          const value = await fn()
-          return { isOrigin: true, value }
         }
 
-    const doRender = maybeCoalesceInvoke(
-      async (): Promise<{
-        html: string | null
-        pageData: any
-        sprRevalidate: number | false
-        isNotFound?: boolean
-        isRedirect?: boolean
-      }> => {
-        let pageData: any
-        let html: string | null
-        let sprRevalidate: number | false
-        let isNotFound: boolean | undefined
-        let isRedirect: boolean | undefined
+        // ensure correct status is set when visiting a status page
+        // directly e.g. /500
+        if (STATIC_STATUS_PAGES.includes(pathname)) {
+          res.statusCode = parseInt(pathname.substr(1), 10)
+        }
 
-        let renderResult
-        // handle serverless
-        if (isLikeServerless) {
-          renderResult = await (components.Component as any).renderReqToHTML(
-            req,
-            res,
-            'passthrough',
-            {
-              locale,
-              locales,
-              defaultLocale,
-              optimizeCss: this.renderOpts.optimizeCss,
-              distDir: this.distDir,
-              fontManifest: this.renderOpts.fontManifest,
-              domainLocales: this.renderOpts.domainLocales,
-            }
-          )
-
-          html = renderResult.html
-          pageData = renderResult.renderOpts.pageData
-          sprRevalidate = renderResult.renderOpts.revalidate
-          isNotFound = renderResult.renderOpts.isNotFound
-          isRedirect = renderResult.renderOpts.isRedirect
-        } else {
-          const origQuery = parseUrl(req.url || '', true).query
-          const hadTrailingSlash =
-            urlPathname !== '/' && this.nextConfig.trailingSlash
-
-          const resolvedUrl = formatUrl({
-            pathname: `${resolvedUrlPathname}${hadTrailingSlash ? '/' : ''}`,
-            // make sure to only add query values from original URL
-            query: origQuery,
+        // handle static page
+        if (typeof components.Component === 'string') {
+          resolveResult({
+            type: 'html',
+            body: components.Component,
           })
+          return
+        }
 
-          const renderOpts: RenderOpts = {
-            ...components,
-            ...opts,
-            isDataReq,
-            resolvedUrl,
-            locale,
-            locales,
-            defaultLocale,
-            // For getServerSideProps and getInitialProps we need to ensure we use the original URL
-            // and not the resolved URL to prevent a hydration mismatch on
-            // asPath
-            resolvedAsPath:
-              hasServerProps || hasGetInitialProps
-                ? formatUrl({
-                    // we use the original URL pathname less the _next/data prefix if
-                    // present
-                    pathname: `${urlPathname}${hadTrailingSlash ? '/' : ''}`,
-                    query: origQuery,
-                  })
-                : resolvedUrl,
-          }
+        if (!query.amp) {
+          delete query.amp
+        }
 
-          renderResult = await renderToHTML(
+        const locale = query.__nextLocale as string
+        const defaultLocale = isSSG
+          ? this.nextConfig.i18n?.defaultLocale
+          : (query.__nextDefaultLocale as string)
+
+        const { i18n } = this.nextConfig
+        const locales = i18n?.locales
+
+        let previewData: PreviewData
+        let isPreviewMode = false
+
+        if (hasServerProps || isSSG) {
+          previewData = tryGetPreviewData(
             req,
             res,
-            pathname,
-            query,
-            renderOpts
+            this.renderOpts.previewProps
           )
-
-          html = renderResult
-          // TODO: change this to a different passing mechanism
-          pageData = (renderOpts as any).pageData
-          sprRevalidate = (renderOpts as any).revalidate
-          isNotFound = (renderOpts as any).isNotFound
-          isRedirect = (renderOpts as any).isRedirect
+          isPreviewMode = previewData !== false
         }
 
-        return { html, pageData, sprRevalidate, isNotFound, isRedirect }
-      }
-    )
+        // Compute the iSSG cache key. We use the rewroteUrl since
+        // pages with fallback: false are allowed to be rewritten to
+        // and we need to look up the path by the rewritten path
+        let urlPathname = parseUrl(req.url || '').pathname || '/'
 
-    const isProduction = !this.renderOpts.dev
-    const isDynamicPathname = isDynamicRoute(pathname)
-    const didRespond = isResSent(res)
+        let resolvedUrlPathname = (req as any)._nextRewroteUrl
+          ? (req as any)._nextRewroteUrl
+          : urlPathname
 
-    const { staticPaths, fallbackMode } = hasStaticPaths
-      ? await this.getStaticPaths(pathname)
-      : { staticPaths: undefined, fallbackMode: false }
+        urlPathname = removePathTrailingSlash(urlPathname)
+        resolvedUrlPathname = normalizeLocalePath(
+          removePathTrailingSlash(resolvedUrlPathname),
+          this.nextConfig.i18n?.locales
+        ).pathname
 
-    // When we did not respond from cache, we need to choose to block on
-    // rendering or return a skeleton.
-    //
-    // * Data requests always block.
-    //
-    // * Blocking mode fallback always blocks.
-    //
-    // * Preview mode toggles all pages to be resolved in a blocking manner.
-    //
-    // * Non-dynamic pages should block (though this is an impossible
-    //   case in production).
-    //
-    // * Dynamic pages should return their skeleton if not defined in
-    //   getStaticPaths, then finish the data request on the client-side.
-    //
-    if (
-      this.minimalMode !== true &&
-      fallbackMode !== 'blocking' &&
-      ssgCacheKey &&
-      !didRespond &&
-      !isPreviewMode &&
-      isDynamicPathname &&
-      // Development should trigger fallback when the path is not in
-      // `getStaticPaths`
-      (isProduction ||
-        !staticPaths ||
-        !staticPaths.includes(
-          // we use ssgCacheKey here as it is normalized to match the
-          // encoding from getStaticPaths along with including the locale
-          query.amp ? ssgCacheKey.replace(/\.amp$/, '') : ssgCacheKey
-        ))
-    ) {
-      if (
-        // In development, fall through to render to handle missing
-        // getStaticPaths.
-        (isProduction || staticPaths) &&
-        // When fallback isn't present, abort this render so we 404
-        fallbackMode !== 'static'
-      ) {
-        throw new NoFallbackError()
-      }
+        const stripNextDataPath = (path: string) => {
+          if (path.includes(this.buildId)) {
+            const splitPath = path.substring(
+              path.indexOf(this.buildId) + this.buildId.length
+            )
 
-      if (!isDataReq) {
-        let html: string
-
-        // Production already emitted the fallback as static HTML.
-        if (isProduction) {
-          html = await this.incrementalCache.getFallback(
-            locale ? `/${locale}${pathname}` : pathname
-          )
-        }
-        // We need to generate the fallback on-demand for development.
-        else {
-          query.__nextFallback = 'true'
-          if (isLikeServerless) {
-            prepareServerlessUrl(req, query)
+            path = denormalizePagePath(splitPath.replace(/\.json$/, ''))
           }
-          const { value: renderResult } = await doRender()
-          html = renderResult.html
+
+          if (this.nextConfig.i18n) {
+            return normalizeLocalePath(path, locales).pathname
+          }
+          return path
         }
 
-        sendPayload(req, res, html, 'html', {
-          generateEtags: this.renderOpts.generateEtags,
-          poweredByHeader: this.renderOpts.poweredByHeader,
-        })
-        return null
-      }
-    }
-
-    const {
-      isOrigin,
-      value: { html, pageData, sprRevalidate, isNotFound, isRedirect },
-    } = await doRender()
-    let resHtml = html
-
-    const revalidateOptions =
-      !this.renderOpts.dev || (hasServerProps && !isDataReq)
-        ? {
-            private: isPreviewMode || is404Page,
-            stateful: !isSSG,
-            revalidate: sprRevalidate,
+        const handleRedirect = (pageData: any) => {
+          const redirect = {
+            destination: pageData.pageProps.__N_REDIRECT,
+            statusCode: pageData.pageProps.__N_REDIRECT_STATUS,
+            basePath: pageData.pageProps.__N_REDIRECT_BASE_PATH,
           }
-        : undefined
+          const statusCode = getRedirectStatus(redirect)
+          const { basePath } = this.nextConfig
 
-    if (
-      !isResSent(res) &&
-      !isNotFound &&
-      (isSSG || isDataReq || hasServerProps)
-    ) {
-      if (isRedirect && !isDataReq) {
-        await handleRedirect(pageData)
-      } else {
-        sendPayload(
-          req,
-          res,
-          isDataReq ? JSON.stringify(pageData) : html,
-          isDataReq ? 'json' : 'html',
-          {
-            generateEtags: this.renderOpts.generateEtags,
-            poweredByHeader: this.renderOpts.poweredByHeader,
-          },
-          revalidateOptions
+          if (
+            basePath &&
+            redirect.basePath !== false &&
+            redirect.destination.startsWith('/')
+          ) {
+            redirect.destination = `${basePath}${redirect.destination}`
+          }
+
+          if (statusCode === PERMANENT_REDIRECT_STATUS) {
+            res.setHeader('Refresh', `0;url=${redirect.destination}`)
+          }
+
+          res.statusCode = statusCode
+          res.setHeader('Location', redirect.destination)
+          res.end()
+        }
+
+        // remove /_next/data prefix from urlPathname so it matches
+        // for direct page visit and /_next/data visit
+        if (isDataReq) {
+          resolvedUrlPathname = stripNextDataPath(resolvedUrlPathname)
+          urlPathname = stripNextDataPath(urlPathname)
+        }
+
+        let ssgCacheKey =
+          isPreviewMode || !isSSG || this.minimalMode
+            ? undefined // Preview mode bypasses the cache
+            : `${locale ? `/${locale}` : ''}${
+                (pathname === '/' || resolvedUrlPathname === '/') && locale
+                  ? ''
+                  : resolvedUrlPathname
+              }${query.amp ? '.amp' : ''}`
+
+        if ((is404Page || is500Page) && isSSG) {
+          ssgCacheKey = `${locale ? `/${locale}` : ''}${pathname}${
+            query.amp ? '.amp' : ''
+          }`
+        }
+
+        if (ssgCacheKey) {
+          // we only encode path delimiters for path segments from
+          // getStaticPaths so we need to attempt decoding the URL
+          // to match against and only escape the path delimiters
+          // this allows non-ascii values to be handled e.g. Japanese characters
+
+          // TODO: investigate adding this handling for non-SSG pages so
+          // non-ascii names work there also
+          ssgCacheKey = ssgCacheKey
+            .split('/')
+            .map((seg) => {
+              try {
+                seg = escapePathDelimiters(decodeURIComponent(seg), true)
+              } catch (_) {
+                // An improperly encoded URL was provided, this is considered
+                // a bad request (400)
+                const err: Error & { code?: string } = new Error(
+                  'failed to decode param'
+                )
+                err.code = 'DECODE_FAILED'
+                throw err
+              }
+              return seg
+            })
+            .join('/')
+        }
+
+        // Complete the response with cached data if its present
+        const cachedData = ssgCacheKey
+          ? await this.incrementalCache.get(ssgCacheKey)
+          : undefined
+
+        if (cachedData) {
+          const data = isDataReq
+            ? JSON.stringify(cachedData.pageData)
+            : cachedData.html
+
+          const revalidateOptions = !this.renderOpts.dev
+            ? {
+                // When the page is 404 cache-control should not be added
+                private: isPreviewMode || is404Page,
+                stateful: false, // GSP response
+                revalidate:
+                  cachedData.curRevalidate !== undefined
+                    ? cachedData.curRevalidate
+                    : /* default to minimum revalidate (this should be an invariant) */ 1,
+              }
+            : undefined
+
+          if (!isDataReq && cachedData.pageData?.pageProps?.__N_REDIRECT) {
+            await handleRedirect(cachedData.pageData)
+          } else if (cachedData.isNotFound) {
+            if (revalidateOptions) {
+              setRevalidateHeaders(res, revalidateOptions)
+            }
+            if (isDataReq) {
+              res.statusCode = 404
+              res.end('{"notFound":true}')
+            } else {
+              await this.render404(req, res, {
+                pathname,
+                query,
+              } as UrlWithParsedQuery)
+            }
+          } else {
+            resolveResult({
+              type: isDataReq ? 'json' : 'html',
+              body: data!,
+              revalidateOptions,
+            })
+          }
+
+          // Stop the request chain here if the data we sent was up-to-date
+          if (!cachedData.isStale) {
+            return null
+          }
+        }
+
+        // If we're here, that means data is missing or it's stale.
+        const maybeCoalesceInvoke = ssgCacheKey
+          ? (fn: any) => withCoalescedInvoke(fn).bind(null, ssgCacheKey!, [])
+          : (fn: any) => async () => {
+              const value = await fn()
+              return { isOrigin: true, value }
+            }
+
+        const doRender = maybeCoalesceInvoke(
+          async (): Promise<{
+            html: string | null
+            pageData: any
+            sprRevalidate: number | false
+            isNotFound?: boolean
+            isRedirect?: boolean
+          }> => {
+            let pageData: any
+            let html: string | null
+            let sprRevalidate: number | false
+            let isNotFound: boolean | undefined
+            let isRedirect: boolean | undefined
+
+            let renderResult
+            // handle serverless
+            if (isLikeServerless) {
+              renderResult = await (components.Component as any).renderReqToHTML(
+                req,
+                res,
+                'passthrough',
+                {
+                  locale,
+                  locales,
+                  defaultLocale,
+                  optimizeCss: this.renderOpts.optimizeCss,
+                  distDir: this.distDir,
+                  fontManifest: this.renderOpts.fontManifest,
+                  domainLocales: this.renderOpts.domainLocales,
+                }
+              )
+
+              html = renderResult.html
+              pageData = renderResult.renderOpts.pageData
+              sprRevalidate = renderResult.renderOpts.revalidate
+              isNotFound = renderResult.renderOpts.isNotFound
+              isRedirect = renderResult.renderOpts.isRedirect
+            } else {
+              const origQuery = parseUrl(req.url || '', true).query
+              const hadTrailingSlash =
+                urlPathname !== '/' && this.nextConfig.trailingSlash
+
+              const resolvedUrl = formatUrl({
+                pathname: `${resolvedUrlPathname}${
+                  hadTrailingSlash ? '/' : ''
+                }`,
+                // make sure to only add query values from original URL
+                query: origQuery,
+              })
+
+              const renderOpts: RenderOpts = {
+                ...components,
+                ...opts,
+                isDataReq,
+                resolvedUrl,
+                locale,
+                locales,
+                defaultLocale,
+                // For getServerSideProps and getInitialProps we need to ensure we use the original URL
+                // and not the resolved URL to prevent a hydration mismatch on
+                // asPath
+                resolvedAsPath:
+                  hasServerProps || hasGetInitialProps
+                    ? formatUrl({
+                        // we use the original URL pathname less the _next/data prefix if
+                        // present
+                        pathname: `${urlPathname}${
+                          hadTrailingSlash ? '/' : ''
+                        }`,
+                        query: origQuery,
+                      })
+                    : resolvedUrl,
+              }
+
+              renderResult = await renderToHTML(
+                req,
+                res,
+                pathname,
+                query,
+                renderOpts
+              )
+
+              html = renderResult
+              // TODO: change this to a different passing mechanism
+              pageData = (renderOpts as any).pageData
+              sprRevalidate = (renderOpts as any).revalidate
+              isNotFound = (renderOpts as any).isNotFound
+              isRedirect = (renderOpts as any).isRedirect
+            }
+
+            return { html, pageData, sprRevalidate, isNotFound, isRedirect }
+          }
         )
-      }
-      resHtml = null
-    }
 
-    // Update the cache if the head request and cacheable
-    if (isOrigin && ssgCacheKey) {
-      await this.incrementalCache.set(
-        ssgCacheKey,
-        { html: html!, pageData, isNotFound, isRedirect },
-        sprRevalidate
-      )
-    }
+        const isProduction = !this.renderOpts.dev
+        const isDynamicPathname = isDynamicRoute(pathname)
+        const didRespond = isResSent(res)
 
-    if (!isResSent(res) && isNotFound) {
-      if (revalidateOptions) {
-        setRevalidateHeaders(res, revalidateOptions)
+        const { staticPaths, fallbackMode } = hasStaticPaths
+          ? await this.getStaticPaths(pathname)
+          : { staticPaths: undefined, fallbackMode: false }
+
+        // When we did not respond from cache, we need to choose to block on
+        // rendering or return a skeleton.
+        //
+        // * Data requests always block.
+        //
+        // * Blocking mode fallback always blocks.
+        //
+        // * Preview mode toggles all pages to be resolved in a blocking manner.
+        //
+        // * Non-dynamic pages should block (though this is an impossible
+        //   case in production).
+        //
+        // * Dynamic pages should return their skeleton if not defined in
+        //   getStaticPaths, then finish the data request on the client-side.
+        //
+        if (
+          this.minimalMode !== true &&
+          fallbackMode !== 'blocking' &&
+          ssgCacheKey &&
+          !didRespond &&
+          !isPreviewMode &&
+          isDynamicPathname &&
+          // Development should trigger fallback when the path is not in
+          // `getStaticPaths`
+          (isProduction ||
+            !staticPaths ||
+            !staticPaths.includes(
+              // we use ssgCacheKey here as it is normalized to match the
+              // encoding from getStaticPaths along with including the locale
+              query.amp ? ssgCacheKey.replace(/\.amp$/, '') : ssgCacheKey
+            ))
+        ) {
+          if (
+            // In development, fall through to render to handle missing
+            // getStaticPaths.
+            (isProduction || staticPaths) &&
+            // When fallback isn't present, abort this render so we 404
+            fallbackMode !== 'static'
+          ) {
+            throw new NoFallbackError()
+          }
+
+          if (!isDataReq) {
+            let html: string
+
+            // Production already emitted the fallback as static HTML.
+            if (isProduction) {
+              html = await this.incrementalCache.getFallback(
+                locale ? `/${locale}${pathname}` : pathname
+              )
+            }
+            // We need to generate the fallback on-demand for development.
+            else {
+              query.__nextFallback = 'true'
+              if (isLikeServerless) {
+                prepareServerlessUrl(req, query)
+              }
+              const { value: renderResult } = await doRender()
+              html = renderResult.html
+            }
+
+            resolveResult({
+              type: 'html',
+              body: html,
+            })
+            return
+          }
+        }
+
+        const {
+          isOrigin,
+          value: { html, pageData, sprRevalidate, isNotFound, isRedirect },
+        } = await doRender()
+        let resHtml = html
+
+        const revalidateOptions =
+          !this.renderOpts.dev || (hasServerProps && !isDataReq)
+            ? {
+                private: isPreviewMode || is404Page,
+                stateful: !isSSG,
+                revalidate: sprRevalidate,
+              }
+            : undefined
+
+        if (
+          !isResSent(res) &&
+          !isNotFound &&
+          (isSSG || isDataReq || hasServerProps)
+        ) {
+          if (isRedirect && !isDataReq) {
+            await handleRedirect(pageData)
+          } else {
+            resolveResult({
+              type: isDataReq ? 'json' : 'html',
+              body: isDataReq ? JSON.stringify(pageData) : html,
+              revalidateOptions,
+            })
+          }
+          resHtml = null
+        }
+
+        // Update the cache if the head request and cacheable
+        if (isOrigin && ssgCacheKey) {
+          await this.incrementalCache.set(
+            ssgCacheKey,
+            { html: html!, pageData, isNotFound, isRedirect },
+            sprRevalidate
+          )
+        }
+
+        if (!isResSent(res) && isNotFound) {
+          if (revalidateOptions) {
+            setRevalidateHeaders(res, revalidateOptions)
+          }
+          if (isDataReq) {
+            res.statusCode = 404
+            res.end('{"notFound":true}')
+          } else {
+            await this.render404(req, res, {
+              pathname,
+              query,
+            } as UrlWithParsedQuery)
+          }
+        }
+        resolveResult(
+          resHtml ? { type: 'html', body: resHtml, revalidateOptions } : null
+        )
+      } catch (err) {
+        rejectResult(err)
       }
-      if (isDataReq) {
-        res.statusCode = 404
-        res.end('{"notFound":true}')
-      } else {
-        await this.render404(req, res, {
-          pathname,
-          query,
-        } as UrlWithParsedQuery)
-      }
-    }
-    return resHtml
+    })
   }
 
   private async renderToResult(
@@ -2021,15 +2038,21 @@ export default class Server {
         'no-cache, no-store, max-age=0, must-revalidate'
       )
     }
-    const html = await this.renderErrorToHTML(err, req, res, pathname, query)
+    const result = await this.renderErrorToResult(
+      err,
+      req,
+      res,
+      pathname,
+      query
+    )
 
     if (this.minimalMode && res.statusCode === 500) {
       throw err
     }
-    if (html === null) {
+    if (result === null) {
       return
     }
-    return this.sendHTML(req, res, html)
+    return this.sendResult(req, res, result)
   }
 
   private customErrorNo404Warn = execOnce(() => {
@@ -2333,5 +2356,6 @@ export class WrappedBuildError extends Error {
 
 type RenderResult = {
   type: 'html' | 'json'
-  body: any
+  body: string
+  revalidateOptions?: any
 }

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -228,6 +228,10 @@ const expectedManifestRoutes = () => ({
   },
 })
 
+function isCachingHeader(cacheControl) {
+  return !cacheControl || !/no-store/.test(cacheControl)
+}
+
 const navigateTest = (dev = false) => {
   it('should navigate between pages successfully', async () => {
     const toBuild = [
@@ -974,18 +978,20 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
 
     it('should always call getStaticProps without caching in dev', async () => {
       const initialRes = await fetchViaHTTP(appPort, '/something')
-      expect(initialRes.headers.get('cache-control')).toBeFalsy()
+      expect(isCachingHeader(initialRes.headers.get('cache-control'))).toBe(
+        false
+      )
       const initialHtml = await initialRes.text()
       expect(initialHtml).toMatch(/hello.*?world/)
 
       const newRes = await fetchViaHTTP(appPort, '/something')
-      expect(newRes.headers.get('cache-control')).toBeFalsy()
+      expect(isCachingHeader(newRes.headers.get('cache-control'))).toBe(false)
       const newHtml = await newRes.text()
       expect(newHtml).toMatch(/hello.*?world/)
       expect(initialHtml !== newHtml).toBe(true)
 
       const newerRes = await fetchViaHTTP(appPort, '/something')
-      expect(newerRes.headers.get('cache-control')).toBeFalsy()
+      expect(isCachingHeader(newerRes.headers.get('cache-control'))).toBe(false)
       const newerHtml = await newerRes.text()
       expect(newerHtml).toMatch(/hello.*?world/)
       expect(newHtml !== newerHtml).toBe(true)


### PR DESCRIPTION
Refactors the internals of `next-server` to use `RenderResult` instead of `string | null` and manual `sendPayload` calls. This is the first step toward streaming support.

I split `renderToResultWithComponents` into a separate `renderToResultWithComponentsInternal` function for ease of review: GitHub's diff rendering was highly misleading, making it seem as though more of the function had changed. The separate function just makes the actual change clearer: we split `renderToHTMLWithComponents` into two promises; one that represents the actual render result, and one that represents all of the work (including background work for e.g. revalidation) that needs to be done as part of generating the result.

These changes make it easier to bubble up a `RenderResult`, instead of sometimes calling `sendPayload` manually, centralizing all payload handling in `sendResult` and eventually a similar function for public APIs that return a string. This centralization will make it much easier to handle a response that needs to be streamed, which will come in another PR soon.