### PR TITLE
More explicit typing for `IncrementalCache`

### DIFF
--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -24,7 +24,7 @@ interface CachedPageValue {
   pageData: Object
 }
 
-type IncrementalCacheValue =
+export type IncrementalCacheValue =
   | CachedRedirectValue
   | CachedNotFoundValue
   | CachedPageValue

--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -10,12 +10,12 @@ function toRoute(pathname: string): string {
 }
 
 interface CachedRedirectValue {
-  kind: 'redirect'
+  kind: 'REDIRECT'
   props: Object
 }
 
 interface CachedPageValue {
-  kind: 'page'
+  kind: 'PAGE'
   html: string
   pageData: Object
 }
@@ -84,7 +84,7 @@ export class IncrementalCache {
       // default to 50MB limit
       max: max || 50 * 1024 * 1024,
       length({ value }) {
-        if (!value || value.kind === 'redirect') return 25
+        if (!value || value.kind === 'REDIRECT') return 25
         // rough estimate of size of cache value
         return value.html.length + JSON.stringify(value.pageData).length
       },
@@ -146,7 +146,7 @@ export class IncrementalCache {
         data = {
           revalidateAfter: this.calculateRevalidate(pathname),
           value: {
-            kind: 'page',
+            kind: 'PAGE',
             html,
             pageData,
           },
@@ -205,7 +205,7 @@ export class IncrementalCache {
 
     // TODO: This option needs to cease to exist unless it stops mutating the
     // `next build` output's manifest.
-    if (this.incrementalOptions.flushToDisk && data?.kind === 'page') {
+    if (this.incrementalOptions.flushToDisk && data?.kind === 'PAGE') {
       try {
         const seedPath = this.getSeedPath(pathname, 'html')
         await promises.mkdir(path.dirname(seedPath), { recursive: true })

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1602,19 +1602,20 @@ export default class Server {
     }
 
     // Complete the response with cached data if its present
-    const cachedData = ssgCacheKey
+    const cacheEntry = ssgCacheKey
       ? await this.incrementalCache.get(ssgCacheKey)
       : undefined
 
-    if (cachedData) {
+    if (cacheEntry) {
+      const cachedData = cacheEntry.value
       const revalidateOptions = !this.renderOpts.dev
         ? {
             // When the page is 404 cache-control should not be added
             private: isPreviewMode || is404Page,
             stateful: false, // GSP response
             revalidate:
-              cachedData.curRevalidate !== undefined
-                ? cachedData.curRevalidate
+              cacheEntry.curRevalidate !== undefined
+                ? cacheEntry.curRevalidate
                 : /* default to minimum revalidate (this should be an invariant) */ 1,
           }
         : undefined
@@ -1663,7 +1664,7 @@ export default class Server {
       }
 
       // Stop the request chain here if the data we sent was up-to-date
-      if (!cachedData.isStale) {
+      if (!cacheEntry.isStale) {
         return null
       }
     }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1633,7 +1633,7 @@ export default class Server {
             query,
           } as UrlWithParsedQuery)
         }
-      } else if (cachedData.kind === 'redirect') {
+      } else if (cachedData.kind === 'REDIRECT') {
         if (isDataReq) {
           sendPayload(
             req,
@@ -1888,9 +1888,9 @@ export default class Server {
       if (isNotFound) {
         cacheValue = null
       } else if (isRedirect) {
-        cacheValue = { kind: 'redirect', props: pageData }
+        cacheValue = { kind: 'REDIRECT', props: pageData }
       } else {
-        cacheValue = { kind: 'page', html, pageData }
+        cacheValue = { kind: 'PAGE', html, pageData }
       }
       await this.incrementalCache.set(ssgCacheKey, cacheValue, sprRevalidate)
     }


### PR DESCRIPTION
Make the typing for `IncrementalCache` more explicit. With streaming, we’ll want to stream page data as well as HTML. This is a bit complicated now because we’re overloading `pageData` for both redirects and pages.

This PR makes the different types explicit. With streaming, the data for redirects is synchronously available, while the data for pages will become a stream.

A follow up PR will add a “stream through” cache in front of `IncrementalCache` 