### PR TITLE
Add `RenderResult` class

### DIFF
--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -3,7 +3,6 @@ import { extname, join, dirname, sep } from 'path'
 import { renderToHTML } from '../server/render'
 import { promises } from 'fs'
 import AmpHtmlValidator from 'next/dist/compiled/amphtml-validator'
-import Observable from 'next/dist/compiled/zen-observable'
 import { loadComponents } from '../server/load-components'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
@@ -19,9 +18,9 @@ import { FontManifest } from '../server/font-utils'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { trace } from '../telemetry/trace'
 import { isInAmpMode } from '../shared/lib/amp'
-import { resultsToString } from '../server/utils'
 import { NextConfigComplete } from '../server/config-shared'
 import { setHttpAgentOptions } from '../server/config'
+import RenderResult from '../server/render-result'
 
 const envConfig = require('../shared/lib/runtime-config')
 
@@ -275,7 +274,7 @@ export default async function exportPage({
 
         // if it was auto-exported the HTML is loaded here
         if (typeof mod === 'string') {
-          renderResult = Observable.of(mod)
+          renderResult = RenderResult.fromStatic(mod)
           queryWithAutoExportWarn()
         } else {
           // for non-dynamic SSG pages we should have already
@@ -353,7 +352,7 @@ export default async function exportPage({
         }
 
         if (typeof components.Component === 'string') {
-          renderResult = Observable.of(components.Component)
+          renderResult = RenderResult.fromStatic(components.Component)
           queryWithAutoExportWarn()
         } else {
           /**
@@ -418,7 +417,7 @@ export default async function exportPage({
         }
       }
 
-      const html = renderResult ? await resultsToString([renderResult]) : ''
+      const html = renderResult ? await renderResult.toUnchunkedString() : ''
       if (inAmpMode && !curRenderOpts.ampSkipValidation) {
         if (!results.ssgNotFound) {
           await validateAmp(html, path, curRenderOpts.ampValidatorPath)
@@ -461,7 +460,7 @@ export default async function exportPage({
           }
 
           const ampHtml = ampRenderResult
-            ? await resultsToString([ampRenderResult])
+            ? await ampRenderResult.toUnchunkedString()
             : ''
           if (!curRenderOpts.ampSkipValidation) {
             await validateAmp(ampHtml, page + '?amp=1')

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -10,7 +10,6 @@ import {
   ParsedUrlQuery,
 } from 'querystring'
 import { format as formatUrl, parse as parseUrl, UrlWithParsedQuery } from 'url'
-import Observable from 'next/dist/compiled/zen-observable'
 import { PrerenderManifest } from '../build'
 import {
   getRedirectStatus,
@@ -77,7 +76,8 @@ import { sendRenderResult, setRevalidateHeaders } from './send-payload'
 import { serveStatic } from './serve-static'
 import { IncrementalCache } from './incremental-cache'
 import { execOnce } from '../shared/lib/utils'
-import { isBlockedPage, RenderResult, resultsToString } from './utils'
+import { isBlockedPage } from './utils'
+import RenderResult from './render-result'
 import { loadEnvConfig } from '@next/env'
 import './node-polyfill-fetch'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
@@ -1274,9 +1274,7 @@ export default class Server {
       return sendRenderResult({
         req,
         res,
-        resultOrPayload: requireStaticHTML
-          ? await resultsToString([body])
-          : body,
+        result: body,
         type,
         generateEtags,
         poweredByHeader,
@@ -1304,7 +1302,12 @@ export default class Server {
     if (payload === null) {
       return null
     }
-    return resultsToString([payload.body])
+    if (payload.body.isDynamic()) {
+      throw new Error(
+        'invariant: expected a static result. This is a bug in Next.js'
+      )
+    }
+    return payload.body.toUnchunkedString()
   }
 
   public async render(
@@ -1478,8 +1481,8 @@ export default class Server {
     if (typeof components.Component === 'string') {
       return {
         type: 'html',
-        // TODO: Static pages should be written as chunks
-        body: Observable.of(components.Component),
+        // TODO: Static pages should be serialized as RenderResult
+        body: RenderResult.fromStatic(components.Component),
       }
     }
 
@@ -1758,7 +1761,7 @@ export default class Server {
               return {
                 value: {
                   kind: 'PAGE',
-                  html: Observable.of(html),
+                  html: RenderResult.fromStatic(html),
                   pageData: {},
                 },
               }
@@ -1837,7 +1840,7 @@ export default class Server {
       if (isDataReq) {
         return {
           type: 'json',
-          body: Observable.of(JSON.stringify(cachedData.props)),
+          body: RenderResult.fromStatic(JSON.stringify(cachedData.props)),
           revalidateOptions,
         }
       } else {
@@ -1848,7 +1851,7 @@ export default class Server {
       return {
         type: isDataReq ? 'json' : 'html',
         body: isDataReq
-          ? Observable.of(JSON.stringify(cachedData.pageData))
+          ? RenderResult.fromStatic(JSON.stringify(cachedData.pageData))
           : cachedData.html,
         revalidateOptions,
       }
@@ -2088,7 +2091,7 @@ export default class Server {
       }
       return {
         type: 'html',
-        body: Observable.of('Internal Server Error'),
+        body: RenderResult.fromStatic('Internal Server Error'),
       }
     }
   }

--- a/packages/next/server/render-result.ts
+++ b/packages/next/server/render-result.ts
@@ -1,0 +1,41 @@
+import Observable from 'next/dist/compiled/zen-observable'
+
+export default class RenderResult {
+  _response: string | Observable<string>
+  _dynamic: boolean
+
+  constructor(response: string | Observable<string>, dynamic: boolean) {
+    this._response = response
+    this._dynamic = dynamic
+  }
+
+  async toUnchunkedString(): Promise<string> {
+    if (typeof this._response === 'string') {
+      return this._response
+    }
+    const chunks: string[] = []
+    await this._response.forEach((chunk) => chunks.push(chunk))
+    return chunks.join('')
+  }
+
+  forEach(fn: (chunk: string) => void): Promise<void> {
+    if (typeof this._response === 'string') {
+      const value = this._response
+      return new Promise((resolve) => {
+        fn(value)
+        resolve()
+      })
+    }
+    return this._response.forEach(fn)
+  }
+
+  isDynamic(): boolean {
+    return this._dynamic
+  }
+
+  static fromStatic(value: string): RenderResult {
+    return new RenderResult(value, false)
+  }
+
+  static empty = RenderResult.fromStatic('')
+}

--- a/packages/next/server/response-cache.ts
+++ b/packages/next/server/response-cache.ts
@@ -1,6 +1,5 @@
-import Observable from 'next/dist/compiled/zen-observable'
 import { IncrementalCache } from './incremental-cache'
-import { RenderResult, resultsToString } from './utils'
+import RenderResult from './render-result'
 
 interface CachedRedirectValue {
   kind: 'REDIRECT'
@@ -79,7 +78,7 @@ export default class ResponseCache {
               cachedResponse.value?.kind === 'PAGE'
                 ? {
                     kind: 'PAGE',
-                    html: Observable.of(cachedResponse.value.html),
+                    html: RenderResult.fromStatic(cachedResponse.value.html),
                     pageData: cachedResponse.value.pageData,
                   }
                 : cachedResponse.value,
@@ -100,7 +99,7 @@ export default class ResponseCache {
             cacheEntry.value?.kind === 'PAGE'
               ? {
                   kind: 'PAGE',
-                  html: await resultsToString([cacheEntry.value.html]),
+                  html: await cacheEntry.value.html.toUnchunkedString(),
                   pageData: cacheEntry.value.pageData,
                 }
               : cacheEntry.value,

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -1,4 +1,3 @@
-import Observable from 'next/dist/compiled/zen-observable'
 import { BLOCKED_PAGES } from '../shared/lib/constants'
 
 export function isBlockedPage(pathname: string): boolean {
@@ -14,21 +13,4 @@ export function cleanAmpPath(pathname: string): string {
   }
   pathname = pathname.replace(/\?$/, '')
   return pathname
-}
-
-export type RenderResult = Observable<string>
-
-export function mergeResults(results: Array<RenderResult>): RenderResult {
-  // @ts-ignore
-  return Observable.prototype.concat.call(...results)
-}
-
-export async function resultsToString(
-  results: Array<RenderResult>
-): Promise<string> {
-  const chunks: string[] = []
-  await mergeResults(results).forEach((chunk: string) => {
-    chunks.push(chunk)
-  })
-  return chunks.join('')
 }


### PR DESCRIPTION
For backward compatibility, we can't send dynamic responses to clients without explicitly opting in. Since requesting a dynamic response is just a hint, we need to keep track of whether the actual response generated is dynamic or not.

This is achieved via the `RenderResult` class, which also helps abstract away details like `Observable` that we'll want to change in the future (e.g. for backpressure).