### PR TITLE
Tweak dynamic HTML generation

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
@@ -116,7 +116,7 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
       previewProps: encodedPreviewProps,
       env: process.env,
       basePath,
-      requireStaticHTML: true, // Serverless target doesn't support streaming
+      supportsDynamicHTML: false, // Serverless target doesn't support streaming
       ..._renderOpts,
     }
     let _nextData = false

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -378,8 +378,8 @@ export default async function exportApp(
       domainLocales: i18n?.domains,
       trailingSlash: nextConfig.trailingSlash,
       disableOptimizedLoading: nextConfig.experimental.disableOptimizedLoading,
-      // TODO: We should support dynamic HTML too
-      requireStaticHTML: true,
+      // Exported pages do not currently support dynamic HTML.
+      supportsDynamicHTML: false,
       concurrentFeatures: nextConfig.experimental.concurrentFeatures,
     }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -194,7 +194,7 @@ export type RenderOptsPartial = {
   defaultLocale?: string
   domainLocales?: DomainLocale[]
   disableOptimizedLoading?: boolean
-  requireStaticHTML?: boolean
+  supportsDynamicHTML?: boolean
   concurrentFeatures?: boolean
   customServer?: boolean
 }
@@ -295,7 +295,7 @@ export async function renderToHTML(
     previewProps,
     basePath,
     devOnlyCacheBusterQueryString,
-    requireStaticHTML,
+    supportsDynamicHTML,
     concurrentFeatures,
   } = renderOpts
 
@@ -883,7 +883,20 @@ export async function renderToHTML(
     }
   }
 
-  const generateStaticHTML = requireStaticHTML || inAmpMode
+  /**
+   * Rules of Static & Dynamic HTML:
+   *
+   *    1.) We must generate static HTML unless the caller explicitly opts
+   *        in to dynamic HTML support.
+   *
+   *    2.) If dynamic HTML support is requested, we must honor that request
+   *        or throw an error. It is the sole responsibility of the caller to
+   *        ensure they aren't e.g. requesting dynamic HTML for an AMP page.
+   *
+   * These rules help ensure that other existing features like request caching,
+   * coalescing, and ISR continue working as intended.
+   */
+  const generateStaticHTML = supportsDynamicHTML !== true
   const renderToStream = (element: React.ReactElement) =>
     new Promise<Observable<string>>((resolve, reject) => {
       const stream = new PassThrough()


### PR DESCRIPTION
Changes `requireStaticHTML` to `supportsDynamicHTML`.

This simplifies things a bit by making static HTML (the behavior until React 18 SSR) the default. Instead, dynamic HTML is the exception, and **callers** (_not_ `renderToHTML`) should carefully decide whether dynamic HTML makes sense for the request they are trying to render.

I also added some comments about this, and tweaked `next-server.ts` to disable dynamic HTML earlier when necessary and ensure that cache/coalescing keys aren't generated for such requests.